### PR TITLE
replace umbrel action inner double quotes with single quote

### DIFF
--- a/actions/import-umbrel-5.sh
+++ b/actions/import-umbrel-5.sh
@@ -7,7 +7,7 @@ UMBREL_HOST=$(jq -r '.["umbrel-host"]' input.json)
 UMBREL_PASS=$(jq -r '.["umbrel-password"]' input.json)
 rm input.json
 >&2 echo "Stopping Umbrel Services"
-sshpass -p "$UMBREL_PASS" ssh -o StrictHostKeyChecking=no umbrel@$UMBREL_HOST "echo \"$UMBREL_PASS\" | >&2 sudo -S /home/umbrel/umbrel/scripts/stop"
+sshpass -p "$UMBREL_PASS" ssh -o StrictHostKeyChecking=no umbrel@$UMBREL_HOST "echo '$UMBREL_PASS' | >&2 sudo -S /home/umbrel/umbrel/scripts/stop"
 >&2 echo "Copying LND Data"
 sshpass -p "$UMBREL_PASS" scp -o StrictHostKeyChecking=no -r -v umbrel@$UMBREL_HOST:/home/umbrel/umbrel/app-data/lightning/data/lnd/* /root/.lnd
 echo -n 'moneyprintergobrrr' > /root/.lnd/pwd.dat

--- a/actions/import-umbrel.sh
+++ b/actions/import-umbrel.sh
@@ -7,7 +7,7 @@ UMBREL_HOST=$(jq -r '.["umbrel-host"]' input.json)
 UMBREL_PASS=$(jq -r '.["umbrel-password"]' input.json)
 rm input.json
 >&2 echo "Stopping Umbrel Services"
-sshpass -p "$UMBREL_PASS" ssh -o StrictHostKeyChecking=no umbrel@$UMBREL_HOST "echo \"$UMBREL_PASS\" | >&2 sudo -S /home/umbrel/umbrel/scripts/stop"
+sshpass -p "$UMBREL_PASS" ssh -o StrictHostKeyChecking=no umbrel@$UMBREL_HOST "echo '$UMBREL_PASS' | >&2 sudo -S /home/umbrel/umbrel/scripts/stop"
 >&2 echo "Copying LND Data"
 sshpass -p "$UMBREL_PASS" scp -o StrictHostKeyChecking=no -r -v umbrel@$UMBREL_HOST:/home/umbrel/umbrel/lnd/* /root/.lnd
 echo -n 'moneyprintergobrrr' > /root/.lnd/pwd.dat

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,12 +1,8 @@
 id: lnd
 title: LND
-version: 0.16.4
+version: 0.16.4.1
 release-notes: |-
-  * Update upstream to lnd [v0.16.4-beta](https://github.com/lightningnetwork/lnd/releases/tag/v0.16.4-beta)
-  * Add actions to migrate from myNode and RaspiBlitz
-  * Remove Proxy as a dependency
-  * Expose Aezeed CipherSeed in properties for wallets created on >= 16.4
-  * Fix non-deterministic bug where a CipherSeed is not created on a fresh install
+  * Fix Umbrel migration actions to allow special characters
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/lnd-wrapper"
 upstream-repo: "https://github.com/lightningnetwork/lnd"

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -145,5 +145,5 @@ export const migration: T.ExpectedExports.migration = compat.migrations
         down: () => { throw new Error('Cannot downgrade') },
       }
     },
-    "0.16.4",
+    "0.16.4.1",
   );


### PR DESCRIPTION
Fixes Umbrel migration action so the password is correctly piped to the umbrel "stop" script.