### PR TITLE
retry restore on server starting error

### DIFF
--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -648,7 +648,7 @@ fn main() -> Result<(), anyhow::Error> {
                         }
                         Ok(output) => {
                             let stderr = String::from_utf8_lossy(&output.stderr);
-                            if stderr.contains("waiting to start") {
+                            if stderr.contains("server is still in the process of starting") {
                                 continue;
                             } else {
                                 eprintln!("Error initiating SCB recovery: {}", stderr);

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,6 +4,7 @@ version: 0.17.4
 release-notes: |-
   * Update upstream to 0.17.4 [Release Notes](https://github.com/lightningnetwork/lnd/releases/tag/v0.17.4-beta)
   * Add warnings for migration actions
+  * Fix Backup restore to retry when LND still starting up
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/lnd-startos"
 upstream-repo: "https://github.com/lightningnetwork/lnd"


### PR DESCRIPTION
LND error when the server was still starting changed, as a result the flag used to retry a backup restore has been changed.