### PR TITLE
add configuration options for allowing zero-conf channels

### DIFF
--- a/configurator/src/lnd.conf.template
+++ b/configurator/src/lnd.conf.template
@@ -70,6 +70,8 @@ healthcheck.chainbackend.attempts=5
 protocol.wumbo-channels={protocol_wumbo_channels}
 protocol.no-anchors={protocol_no_anchors}
 protocol.no-script-enforced-lease={protocol_disable_script_enforced_lease}
+protocol.option-scid-alias={protocol_option_scid_alias}
+protocol.zero-conf={protocol_zero_conf}
 
 [bolt]
 db.bolt.nofreelistsync={db_bolt_no_freelist_sync}

--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -175,6 +175,8 @@ struct AdvancedConfig {
     max_commit_fee_rate_anchors: usize,
     max_pending_channels: usize,
     protocol_wumbo_channels: bool,
+    protocol_zero_conf: bool,
+    protocol_option_scid_alias: bool,
     protocol_no_anchors: bool,
     protocol_disable_script_enforced_lease: bool,
     gc_canceled_invoices_on_startup: bool,
@@ -431,6 +433,8 @@ fn main() -> Result<(), anyhow::Error> {
         autopilot_min_confirmations = config.autopilot.advanced.min_confirmations,
         autopilot_confirmation_target = config.autopilot.advanced.confirmation_target,
         protocol_wumbo_channels = config.advanced.protocol_wumbo_channels,
+        protocol_zero_conf = config.advanced.protocol_zero_conf,
+        protocol_option_scid_alias = config.advanced.protocol_option_scid_alias,
         protocol_no_anchors = config.advanced.protocol_no_anchors,
         protocol_disable_script_enforced_lease =
             config.advanced.protocol_disable_script_enforced_lease,

--- a/scripts/models/setConfig.ts
+++ b/scripts/models/setConfig.ts
@@ -49,6 +49,8 @@ export const matchAdvanced2 = shape({
   "max-pending-channels": number,
   "max-commit-fee-rate-anchors": number,
   "protocol-wumbo-channels": boolean,
+  "protocol-zero-conf": boolean,
+  "protocol-option-scid-alias": boolean,
   "protocol-no-anchors": boolean,
   "protocol-disable-script-enforced-lease": boolean,
   "gc-canceled-invoices-on-startup": boolean,

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -432,6 +432,8 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
         "name": "Enable zero-conf Channels",
         "description":
           "Set to enable support for zero-conf channels. This requires the option-scid-alias flag to also be set.\n",
+        "warning": 
+          "Zero-conf channels are channels that do not require confirmations to be used. Because of this, the fundee must trust the funder to not double-spend the channel and steal the balance of the channel.",
         "default": false,
       },
       "protocol-option-scid-alias": {

--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -427,6 +427,20 @@ export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({
           "If set, then lnd will create and accept requests for channels larger than 0.16 BTC\n",
         "default": false,
       },
+      "protocol-zero-conf": {
+        "type": "boolean",
+        "name": "Enable zero-conf Channels",
+        "description":
+          "Set to enable support for zero-conf channels. This requires the option-scid-alias flag to also be set.\n",
+        "default": false,
+      },
+      "protocol-option-scid-alias": {
+        "type": "boolean",
+        "name": "Enable option-scid-alias Channels",
+        "description":
+          "Set to enable support for option_scid_alias channels, which can be referred to by an alias instead of the confirmed ShortChannelID. Additionally, is needed to open zero-conf channels.\n",
+        "default": false,
+      },
       "protocol-no-anchors": {
         "type": "boolean",
         "name": "Disable Anchor Channels",

--- a/scripts/services/setConfig.ts
+++ b/scripts/services/setConfig.ts
@@ -31,6 +31,13 @@ const configRules: Array<Check> = [
       }
     },
   },
+  {
+    currentError(config) {
+      if (config.advanced["protocol-zero-conf"] && !config.advanced["protocol-option-scid-alias"]) {
+        return "'Advanced > Enable option-scid-alias Channels' must be enabled to enable zero-conf channels'";
+      }
+    },
+  },
 ];
 
 function checkConfigRules(config: Root): T.KnownError | void {

--- a/scripts/services/setConfig.ts
+++ b/scripts/services/setConfig.ts
@@ -38,6 +38,13 @@ const configRules: Array<Check> = [
       }
     },
   },
+  {
+    currentError(config) {
+      if (config.advanced["protocol-zero-conf"] && config.advanced["protocol-no-anchors"]) {
+        return "'Advanced > Disable Anchor Channels' must be disabled to enable zero-conf channels'";
+      }
+    },
+  },
 ];
 
 function checkConfigRules(config: Root): T.KnownError | void {


### PR DESCRIPTION
I am experimenting with Zeus Olympus LSP, which uses 0-conf (zero-conf) channels for easy onboarding.

This requires two options enabled in LND: https://github.com/lightningnetwork/lnd/blob/master/docs/zero_conf_channels.md

This PR adds those configuration options (keeping the default to false, as it is now).

In Zeus, before:

![Screenshot_20240516_181637_ZEUS](https://github.com/Start9Labs/lnd-startos/assets/130373/2358af9d-c55b-445f-932e-66a8d10f021b)

After enabling the new settings:

![Screenshot_20240516_181954_ZEUS](https://github.com/Start9Labs/lnd-startos/assets/130373/7f375170-d61d-4b74-a03e-04f30e271afa)
