### PR TITLE
LND conf: enable bLIP-50: LSP Spec Transport Layer

### DIFF
--- a/configurator/src/lnd.conf.template
+++ b/configurator/src/lnd.conf.template
@@ -73,6 +73,7 @@ protocol.no-script-enforced-lease={protocol_disable_script_enforced_lease}
 protocol.option-scid-alias={protocol_option_scid_alias}
 protocol.zero-conf={protocol_zero_conf}
 protocol.simple-taproot-chans={protocol_simple_taproot_chans}
+protocol.custom-message=37913
 
 [sweeper]
 sweeper.maxfeerate={sweeper_maxfeerate}


### PR DESCRIPTION
LSPS0/bLIP-50 has recently been [merged into the bLIP spec](https://github.com/lightning/blips/blob/master/blip-0050.md). This is a communication protocol over Lightning's p2p messaging layer called BOLT8, and is used for clients to communicate with Lightning Service Providers and vice versa.

At present, LND doesn't allow applications to communicate over BOLT8 with message types higher than 32768, without building with the `dev` tag or modifying the LND configuration. LSPS0/bLIP-50 uses type 37913.

This configuration change will allow StartOS users to interface with LSP spec-compliant services, such as ZEUS' Olympus.