### PR TITLE
Fix/password migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "@start9labs/start-sdk": "^0.4.0-beta.41",
         "bitcoind-startos": "git+https://github.com/Start9Labs/bitcoind-startos.git#update/040",
         "js-yaml": "^4.1.0",
-        "mime": "^4.0.7"
+        "mime": "^4.0.7",
+        "rfc4648": "1.5.4"
       },
       "devDependencies": {
         "@types/node": "^22.1.0",
@@ -239,6 +240,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@start9labs/start-sdk": "^0.4.0-beta.41",
     "bitcoind-startos": "git+https://github.com/Start9Labs/bitcoind-startos.git#update/040",
+    "rfc4648": "1.5.4",
     "js-yaml": "^4.1.0",
     "mime": "^4.0.7"
   },

--- a/startos/actions/aezeedCipherSeed.ts
+++ b/startos/actions/aezeedCipherSeed.ts
@@ -12,13 +12,18 @@ export const aezeedCipherSeed = sdk.Action.withoutInput(
     warning: null,
     allowedStatuses: 'any',
     group: null,
-    visibility: 'enabled',
+    visibility: (await storeJson.read().const(effects))?.aezeedCipherSeed
+      ? 'enabled'
+      : {
+          disabled:
+            'No Cipher Seed found. The Aezeed Cipher Seed is not available on StartOS for some nodes initialized on earlier versions of LND. It is not possible to retreive the Seed from wallets created on these earlier versions.\nIf you would like to have a Cipher Seed backup, you will need to close your existing channels and move any on-chain funds to an intermediate wallet before creating a new LND wallet',
+        },
   }),
 
   // the execution function
   async ({ effects }) => {
     const aezeedCipherSeed = (await storeJson.read().const(effects))
-      ?.aezeedCipherSeed
+      ?.aezeedCipherSeed!
 
     return {
       version: '1',
@@ -27,9 +32,7 @@ export const aezeedCipherSeed = sdk.Action.withoutInput(
         'Seed for restoring on-chain ONLY funds. This seed has no knowledge of channel state. This is NOT a BIP-39 seed; As such it cannot be used to recover on-chain funds to any wallet other than LND.',
       result: {
         type: 'single',
-        value: aezeedCipherSeed
-          ? aezeedCipherSeed.map((word, i) => `${i + 1}: ${word}`).join(' ')
-          : 'No Cipher Seed found. The Aezeed Cipher Seed is not available on StartOS for some nodes initialized on earlier versions of LND. It is not possible to retreive the Seed from wallets created on these earlier versions.\nIf you would like to have a Cipher Seed backup, you will need to close your existing channels and move any on-chain funds to an intermediate wallet before creating a new LND wallet',
+        value: aezeedCipherSeed.map((word, i) => `${i + 1}: ${word}`).join(' '),
         copyable: true,
         qr: false,
         masked: !!aezeedCipherSeed,

--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -10,12 +10,12 @@ import { taskSetBackend } from './taskSetBackend'
 
 export const init = sdk.setupInit(
   restoreInit,
+  setupCerts,
   versionGraph,
   setInterfaces,
   setDependencies,
   actions,
   watchHosts,
-  setupCerts,
   taskSetBackend,
 )
 

--- a/startos/install/versions/index.ts
+++ b/startos/install/versions/index.ts
@@ -1,3 +1,4 @@
-export { v0_19_3_1_beta_0 as current } from './v0.19.3-beta_1-beta.0'
+export { v0_19_3_1_beta_1 as current } from './v0.19.3-beta_1-beta.1'
+import { v0_19_3_1_beta_0 } from './v0.19.3-beta_1-beta.0'
 
-export const other = []
+export const other = [v0_19_3_1_beta_0]

--- a/startos/install/versions/v0.19.3-beta_1-beta.0.ts
+++ b/startos/install/versions/v0.19.3-beta_1-beta.0.ts
@@ -139,7 +139,6 @@ export const v0_19_3_1_beta_0 = VersionInfo.of({
                     const new_password = base64.stringify(
                       Buffer.from(walletPassword),
                     )
-                    console.log('new_password: ', new_password)
 
                     const res = await subcontainer.exec([
                       'curl',
@@ -155,8 +154,6 @@ export const v0_19_3_1_beta_0 = VersionInfo.of({
                         new_password,
                       }),
                     ])
-
-                    console.log('changepassword response', res)
 
                     if (res.stdout.includes('admin_macaroon')) {
                       console.log(

--- a/startos/install/versions/v0.19.3-beta_1-beta.1.ts
+++ b/startos/install/versions/v0.19.3-beta_1-beta.1.ts
@@ -1,10 +1,9 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 import { readFile } from 'fs/promises'
 import { storeJson } from '../../fileModels/store.json'
-import { load } from 'js-yaml'
 import { lndConfFile } from '../../fileModels/lnd.conf'
 import { lndConfDefaults, lndDataDir, mainMounts, sleep } from '../../utils'
-import { base32, base64 } from 'rfc4648'
+import { base64 } from 'rfc4648'
 import { sdk } from '../../sdk'
 import { restPort } from '../../interfaces'
 

--- a/startos/install/versions/v0.19.3-beta_1-beta.1.ts
+++ b/startos/install/versions/v0.19.3-beta_1-beta.1.ts
@@ -1,0 +1,151 @@
+import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
+import { readFile } from 'fs/promises'
+import { storeJson } from '../../fileModels/store.json'
+import { load } from 'js-yaml'
+import { lndConfFile } from '../../fileModels/lnd.conf'
+import { lndConfDefaults, lndDataDir, mainMounts, sleep } from '../../utils'
+import { base32, base64 } from 'rfc4648'
+import { sdk } from '../../sdk'
+import { restPort } from '../../interfaces'
+
+export const v0_19_3_1_beta_1 = VersionInfo.of({
+  version: '0.19.3-beta:1-beta.1',
+  releaseNotes: 'Revamped for StartOS 0.4.0',
+  migrations: {
+    up: async ({ effects }) => {
+      const walletPassword = await storeJson
+        .read((e) => e.walletPassword)
+        .once()
+
+      if (!walletPassword) return
+
+      try {
+        await readFile('/media/startos/volumes/main/pwd.dat')
+        return
+      } catch (error) {
+        console.log('No pwd.dat found')
+      }
+
+      const osIp = await sdk.getOsIp(effects)
+
+      await lndConfFile.merge(effects, {
+        'bitcoind.rpchost': lndConfDefaults['bitcoind.rpchost'],
+        'bitcoind.rpcuser': undefined,
+        'bitcoind.rpcpass': undefined,
+        'bitcoind.zmqpubrawblock': lndConfDefaults['bitcoind.zmqpubrawblock'],
+        'bitcoind.zmqpubrawtx': lndConfDefaults['bitcoind.zmqpubrawtx'],
+        'bitcoind.rpccookie': lndConfDefaults['bitcoind.rpccookie'],
+        'tor.socks': `${osIp}:9050`,
+        rpclisten: lndConfDefaults.rpclisten,
+        restlisten: lndConfDefaults.restlisten,
+      })
+
+      const node = await lndConfFile.read((e) => e['bitcoin.node']).once()
+
+      let mounts = mainMounts
+      if (node === 'bitcoind') {
+        mounts = mounts.mountDependency({
+          dependencyId: 'bitcoind',
+          mountpoint: '/mnt/bitcoin',
+          readonly: true,
+          subpath: null,
+          volumeId: 'main',
+        })
+
+        try {
+          await effects.setDependencies({
+            dependencies: [
+              {
+                id: 'bitcoind',
+                kind: 'running',
+                versionRange: '>=29.1:2-beta.0',
+                healthChecks: ['primary'],
+              },
+            ],
+          })
+          const depResult = await sdk.checkDependencies(effects)
+
+          depResult.throwIfRunningNotSatisfied('bitcoind')
+          depResult.throwIfInstalledVersionNotSatisfied('bitcoind')
+          depResult.throwIfTasksNotSatisfied('bitcoind')
+          depResult.throwIfHealthNotSatisfied('bitcoind', 'primary')
+        } catch (error) {
+          console.log('Error: ', error)
+          throw new Error(
+            'Bitcoin must be updated and running before LND can be updated.',
+          )
+        }
+      }
+
+      const lndSub = await sdk.SubContainer.of(
+        effects,
+        { imageId: 'lnd' },
+        mounts,
+        'lnd-sub',
+      )
+
+      await sdk.Daemons.of(effects, async () => null)
+        .addDaemon('primary', {
+          exec: { command: ['lnd'] },
+          subcontainer: lndSub,
+          ready: {
+            display: 'REST Interface',
+            fn: () =>
+              sdk.healthCheck.checkPortListening(effects, restPort, {
+                successMessage:
+                  'The REST interface is ready to accept connections',
+                errorMessage: 'The REST Interface is not ready',
+              }),
+          },
+          requires: [],
+        })
+        .addOneshot('changepassword', {
+          exec: {
+            fn: async (subcontainer, abort) => {
+              while (true) {
+                if (abort.aborted) {
+                  console.log('changepassword aborted')
+                  break
+                }
+                try {
+                  const new_password = base64.stringify(
+                    Buffer.from(walletPassword),
+                  )
+
+                  const res = await subcontainer.exec([
+                    'curl',
+                    '--no-progress-meter',
+                    '-X',
+                    'POST',
+                    '--cacert',
+                    `${lndDataDir}/tls.cert`,
+                    'https://lnd.startos:8080/v1/changepassword',
+                    '-d',
+                    JSON.stringify({
+                      current_password: walletPassword,
+                      new_password,
+                    }),
+                  ])
+
+                  console.log('changepassword response', res)
+
+                  if (res.stdout.includes('admin_macaroon')) {
+                    console.log('Password successfully changed to base64')
+                    break
+                  }
+                  sleep(10_000)
+                } catch (e) {
+                  console.log(`Error running changepassword: `, e)
+                }
+              }
+              return null
+            },
+          },
+          subcontainer: lndSub,
+          requires: ['primary'],
+        })
+        .runUntilSuccess(120_000)
+    },
+    down: IMPOSSIBLE,
+  },
+})


### PR DESCRIPTION
- Migrate binary wallet passwords to base32 (for really old LND updates -> 040)
- Unlock wallet with base64 encoding of walletPassword; Previous lnd-startos 040 release candidates created the wallet with a random string rather than the base64 encoding of the random string. To ensure alpha releases can still unlock wallets initialized on one of these earlier RCs, this release also includes a migration to change the password to the base64 encoding of the random string (the walletPassword in the store is unchanged)