### PR TITLE
chore: bump to start-sdk 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,3 @@
-## How the upstream version is pulled
-- dockerTag in `startos/manifest/index.ts`: `lightninglabs/lnd:v<version>`
+# CLAUDE.md
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the doc map and contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,36 @@
 # Contributing
 
-## Building and Development
+This repo packages [LND](https://github.com/lightningnetwork/lnd) for StartOS.
 
-See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for complete environment setup and build instructions.
+## Documentation — keep it in sync
 
-### Quick Start
+- **`README.md`** — what this package is and how it's built (image, volumes, interfaces). For developers and AI assistants.
+- **`instructions.md`** — the user-facing instructions packed into the `.s9pk` and shown on the **Instructions** tab in StartOS, for the person running the service.
+- **`CONTRIBUTING.md`** — this file.
+- **`CLAUDE.md`** — operating rules for AI developers working in this repo.
+
+**Any code change that warrants it must update `README.md` and `instructions.md` in the same change** — a new or renamed action, an added or removed volume / port / interface / dependency, a changed default, a new limitation, any altered user-visible behavior. Don't defer: a package that ships with a stale README or stale instructions is not done, even if the code is perfect. Content rules live in the packaging guide: [Writing READMEs](https://docs.start9.com/packaging/writing-readmes.html) and [Writing Service Instructions](https://docs.start9.com/packaging/writing-instructions.html).
+
+## Building
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for environment setup, then:
 
 ```bash
-# Install dependencies
-npm ci
-
-# Build universal package
-make
+npm ci    # install dependencies
+make      # build the universal .s9pk
 ```
 
-## How to Contribute
+## Updating the upstream version
 
-1. Fork the repository and create a branch from `master`
-2. Make your changes
-3. Open a pull request to `master`
+LND runs the upstream `lightninglabs/lnd` image, pinned by tag in the manifest. To track a new upstream release:
+
+1. Bump `dockerTag` in `startos/manifest/index.ts` to `lightninglabs/lnd:v<new version>`.
+2. Update `version` and `releaseNotes` in the file under `startos/versions/`, renaming it to the new version string. A *new* version file is only needed when the bump carries an `up`/`down` migration, or when you want the old release notes preserved in git history — see [Versions](https://docs.start9.com/packaging/versions.html).
+3. Rebuild (`make`), sideload the `.s9pk`, and confirm it starts.
+4. Review `README.md` and `instructions.md` for anything the bump changed.
+
+## How to contribute
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes — including the doc updates above.
+3. Open a pull request to `master`.

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,60 @@
+# LND
+
+## Documentation
+
+- [Start9 Lightning wallets guide](https://docs.start9.com/bitcoin-guides/lightning-wallets) — how to connect popular Lightning wallets to a StartOS node.
+- [LND operator documentation](https://docs.lightning.engineering/lightning-network-tools/lnd) — the upstream guide to running, configuring, and using LND.
+
+## What you get on StartOS
+
+- A full **LND** Lightning Network node running on Bitcoin mainnet, with Tor enabled by default.
+- **REST LND Connect** and **gRPC LND Connect** interfaces exporting `lndconnect://` URIs (with embedded macaroon and cert) for plugging LND into wallets and apps.
+- A **Peer Interface** for inbound Lightning connections from other nodes.
+- A **Watchtower** interface for letting other nodes use this node as their watchtower, available once the watchtower server is enabled.
+- Wallet lifecycle (create, password storage, auto-unlock) is handled by StartOS — you never run `lncli create` or `lncli unlock`.
+
+## Getting set up
+
+LND posts two critical tasks after install. You can't start the service until both are done.
+
+1. Run the **Initialize Wallet** task. Choose **Start Fresh** to create a new wallet, **Migrate from Umbrel** to import from an Umbrel 1.x node, or **Migrate from StartOS** to import from another StartOS server. On Start Fresh, LND displays your 24-word Aezeed cipher seed **once** — write it down and store it somewhere safe before dismissing. The seed restores on-chain funds only; it does not back up channel state. This is not a BIP-39 seed and only works with LND.
+2. Run the **Bitcoin Backend** task and choose **Bitcoin Core** (recommended if you run Bitcoin Core on this server) or **Neutrino** (built-in light client, no Bitcoin dependency). Selecting Bitcoin Core will post a critical task on Bitcoin Core to enable ZMQ.
+3. Start LND. Your wallet is unlocked automatically on every start.
+
+## Using LND
+
+### Connecting wallets and apps
+
+Open the **REST LND Connect** or **gRPC LND Connect** interface and copy the `lndconnect://` URI (or scan the QR code) into your wallet or app. The URI carries the admin macaroon and the self-signed TLS certificate; treat it like a password. The REST and gRPC interfaces only appear once the wallet has been initialized.
+
+### Peer connections
+
+Other Lightning nodes connect to you over the **Peer Interface**. To share your node's peer URI, run the **Node Info** action.
+
+### Configuration
+
+LND is configured through actions rather than by editing `lnd.conf` directly. Every action writes to `lnd.conf` and takes effect on the next start (or immediately, where LND supports it).
+
+- **General Settings** — node alias, color, accept keysend, accept AMP, and Tor controls. **Route outbound through Tor** (on by default) sends LND's outbound peer connections through the Tor SOCKS proxy; turn it off for clearnet-first outbound or if Tor is interfering with wallet sync. **Use Tor for all traffic** further forces Tor for clearnet-reachable peers and only applies when outbound Tor is on. Inbound peers always reach this node via the StartOS-managed Tor hidden service.
+- **Routing Fees** — base fee, fee rate, and CLTV delta for forwarded payments.
+- **Channel Settings** — default confirmations, min/max channel size, wumbo, zero-conf, SCID alias, pending-channel limit, circular routes, reject-push, and cooperative-close target.
+- **Autopilot Settings** — enable automatic channel management and set max channels, allocation, channel size, privacy, and confirmation targets.
+- **Performance** — database auto-compact, invoice GC, reconnect stagger, gossip and graph-pruning settings.
+- **Watchtower Server** — enable the watchtower server and select which of this node's watchtower addresses to advertise. With it enabled, the **Watchtower Server Info** action becomes available.
+- **Watchtower Client Settings** — enable the watchtower client and add tower URIs (`pubkey@host:9911`).
+
+### Actions
+
+- **Node Info** — display the node alias, public key, and peer URI(s); shareable with other operators who want to open a channel with you.
+- **Watchtower Server Info** — display this node's tower URI for sharing with peers; available once the watchtower server is enabled.
+- **Reset Wallet Transactions** — rescan on-chain transactions from the wallet birthday. Use this if LND has missed an on-chain transaction. LND restarts to apply the reset.
+- **Recreate Macaroons** — delete every macaroon and regenerate them on next start. Use this if a macaroon has been leaked or to rotate credentials. Any wallet or service currently using an old macaroon will need to be reconnected with the new `lndconnect://` URI afterwards.
+
+### Restoring from backup
+
+If you restore LND from a StartOS backup, LND automatically requests force-close of every channel from the Static Channel Backup, and a persistent health-check warning is shown. **Lightning Labs strongly recommends against continued use of a restored LND node.** Once funds are back on-chain, sweep them to another wallet, uninstall LND, and reinstall fresh.
+
+## Limitations
+
+- **Mainnet only.** Testnet, signet, and regtest are not available.
+- **No manual wallet management.** `lncli create` and `lncli unlock` are not used — StartOS handles wallet creation and unlocking. Direct edits to `lnd.conf` are overwritten by the configuration actions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "lnd-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3",
+        "@start9labs/start-sdk": "1.5.0",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -64,9 +64,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -74,12 +74,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -90,9 +90,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -111,30 +111,10 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#e873695fc4e9fa5a21d13db9b56edbb1dab48d08",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#b3bc91c970db6822b38228b07b646ec7ad3138fa",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
+        "@start9labs/start-sdk": "1.3.3",
         "diskusage": "^1.2.0"
-      }
-    },
-    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "^4.3.6",
-        "zod-deep-partial": "^1.2.0"
       }
     },
     "node_modules/deep-equality-data-structures": {
@@ -164,9 +144,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -175,13 +155,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -190,8 +171,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -234,9 +215,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -284,9 +265,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -306,9 +287,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -366,10 +347,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -386,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3",
+    "@start9labs/start-sdk": "1.5.0",
     "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
     "mime": "^4.0.7",
     "rfc4648": "1.5.4"
+  },
+  "overrides": {
+    "@start9labs/start-sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.1.0",

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -45,6 +45,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
         preferredExternalPort: restPort,
         addSsl: {
           alpn: null,
+          auth: null,
           preferredExternalPort: restPort,
           addXForwardedHeaders: false,
         },
@@ -72,6 +73,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
         preferredExternalPort: gRPCPort,
         addSsl: {
           alpn: null,
+          auth: null,
           preferredExternalPort: gRPCPort,
           addXForwardedHeaders: false,
         },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -17,10 +17,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/lightningnetwork/lnd',
   marketingUrl: 'https://lightning.engineering/',
   donationUrl: null,
-  docsUrls: [
-    'https://docs.start9.com/bitcoin-guides/lightning-wallets',
-    'https://docs.lightning.engineering/lightning-network-tools/lnd',
-  ],
   description: { short, long },
   volumes: ['main'],
   images: {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_20_1_beta_4 } from './v0.20.1.beta.4'
+import { v_0_20_1_beta_5 } from './v0.20.1.beta.5'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_20_1_beta_4,
+  current: v_0_20_1_beta_5,
   other: [],
 })

--- a/startos/versions/v0.20.1.beta.5.ts
+++ b/startos/versions/v0.20.1.beta.5.ts
@@ -13,14 +13,14 @@ type OldConfig = {
   }
 }
 
-export const v_0_20_1_beta_4 = VersionInfo.of({
-  version: '0.20.1-beta:4',
+export const v_0_20_1_beta_5 = VersionInfo.of({
+  version: '0.20.1-beta:5',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: '- Updated to start-sdk 1.5.0.',
+    es_ES: '- Actualizado a start-sdk 1.5.0.',
+    de_DE: '- Aktualisierung auf start-sdk 1.5.0.',
+    pl_PL: '- Zaktualizowano do start-sdk 1.5.0.',
+    fr_FR: '- Mise à jour vers start-sdk 1.5.0.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Updates `@start9labs/start-sdk` from 1.3.3 → 1.5.0.
- Adapts to the breaking change in `AddSslOptions` (SDK 1.3.4 made `auth` required, can be `null`) — REST and gRPC bindings in `startos/interfaces.ts` now pass `auth: null`.
- Adds an `overrides` entry pinning the nested SDK pulled in by `bitcoin-core-startos` (still on 1.3.3) to 1.5.0. Without this, npm installs both SDK versions side-by-side and TypeScript can no longer unify the `Action<…>` type when handing `autoconfig` to `sdk.action.createTask(...)`, so the bitcoind autoconfig task in `startos/dependencies.ts` fails typecheck. The override de-dupes to a single SDK and lets type inference succeed.
- Bumps the package version `0.20.1-beta:4` → `:5` and renames the version file in place (no migration change).

Upstream LND is unchanged — latest stable is still `v0.20.1-beta` (the next release is currently in `rc1`). `npm update` did not produce other version changes worth noting.

Verified `npm run check` and `make` (both arches) pass.

## Test plan

- [x] `npm run check` (typecheck) passes
- [x] `make` builds `lnd_x86_64.s9pk` and `lnd_aarch64.s9pk`