### PR TITLE
chore: refresh dependencies (npm update)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#132f3e72902ba899713b898b7534c479ccac7363",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.1",
         "diskusage": "^1.2.0"
@@ -382,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Routine maintenance pass. No code changes needed:

- **SDK** — already at `1.5.1` (latest).
- **Upstream LND** — already pinned at `v0.20.1-beta` (latest stable; `v0.21.0-beta.rc1` is a prerelease, skipped).
- **Dependencies** — `npm update` advanced the pinned `bitcoin-core-startos#next/28.x` commit. The new commit adds sync/reindex completion notifications and i18n strings inside `main.ts` only; this package imports `manifest` and `autoconfig`, neither of which changed, so the bundled output is functionally unchanged.
- **README / instructions** — re-read, still accurate.

## Test plan

- [x] `npm run check` (tsc) clean
- [x] `npm run build` (ncc) clean
- [x] `make` produces both `lnd_x86_64.s9pk` and `lnd_aarch64.s9pk`