### PR TITLE
chore: bump @start9labs/start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "lnd-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
@@ -64,9 +64,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -111,9 +111,9 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },
@@ -382,7 +382,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
     "mime": "^4.0.7",
     "rfc4648": "1.5.4"

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -131,7 +131,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
       protocol: null,
       addSsl: null,
       preferredExternalPort: watchtowerPort,
-      secure: null,
+      secure: { ssl: false },
     },
   )
   const watchtower = sdk.createInterface(effects, {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_20_1_beta_6 } from './v0.20.1.beta.6'
+import { v_0_20_1_beta_7 } from './v0.20.1.beta.7'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_20_1_beta_6,
+  current: v_0_20_1_beta_7,
   other: [],
 })

--- a/startos/versions/v0.20.1.beta.7.ts
+++ b/startos/versions/v0.20.1.beta.7.ts
@@ -13,14 +13,44 @@ type OldConfig = {
   }
 }
 
-export const v_0_20_1_beta_6 = VersionInfo.of({
-  version: '0.20.1-beta:6',
+export const v_0_20_1_beta_7 = VersionInfo.of({
+  version: '0.20.1-beta:7',
   releaseNotes: {
-    en_US: 'Fixes repeated "Sync Complete" notifications when LND briefly flickered out of and back into the synced state.',
-    es_ES: 'Corrige notificaciones repetidas de "Sincronización completa" cuando LND salía y volvía brevemente al estado sincronizado.',
-    de_DE: 'Behebt wiederholte „Sync Complete"-Benachrichtigungen, wenn LND kurzzeitig aus dem synchronisierten Zustand fiel und wieder hineinkam.',
-    pl_PL: 'Naprawia powtarzające się powiadomienia „Sync Complete", gdy LND chwilowo wypadał ze stanu zsynchronizowanego i do niego wracał.',
-    fr_FR: 'Corrige les notifications « Sync Complete » répétées lorsque LND sortait brièvement de l\'état synchronisé puis y revenait.',
+    en_US: `**Fixes**
+
+- Watchtower interface now advertises clearnet addresses, not only Tor onions.
+
+**Internal**
+
+- start-sdk → 1.5.2`,
+    es_ES: `**Correcciones**
+
+- La interfaz Watchtower ahora anuncia direcciones de red abierta, no solo onions de Tor.
+
+**Interno**
+
+- start-sdk → 1.5.2`,
+    de_DE: `**Korrekturen**
+
+- Die Watchtower-Schnittstelle bietet jetzt Klarnetz-Adressen an, nicht nur Tor-Onions.
+
+**Intern**
+
+- start-sdk → 1.5.2`,
+    pl_PL: `**Poprawki**
+
+- Interfejs Watchtower udostępnia teraz adresy w sieci jawnej, a nie tylko adresy Tor onion.
+
+**Wewnętrzne**
+
+- start-sdk → 1.5.2`,
+    fr_FR: `**Corrections**
+
+- L'interface Watchtower expose désormais des adresses en clair, pas uniquement des onions Tor.
+
+**Interne**
+
+- start-sdk → 1.5.2`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.1 → 1.5.2.

## SDK 1.5.2

Fixes `Backups.withPgDump` / `Backups.withMysqlDump` to stage dumps in the subcontainer rootfs before copying through the FUSE backup mount, recovering from a regression that produced 0-byte dumps. LND's backups use `sdk.Backups.ofVolumes('main')` and don't touch the DB-dump helpers, so the fix is irrelevant to this package — bump is taken purely for SDK alignment across the fleet.

## Upstream

LND latest stable is still `v0.20.1-beta` (matches the current pin). The newer `v0.21.0-beta.rc1` is a release candidate; not tracked.

## Test plan

- [x] `make` produces clean `lnd_x86_64.s9pk` and `lnd_aarch64.s9pk` against SDK 1.5.2.