### PR TITLE
fix: stop re-firing Sync Complete notification on sync flicker

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -60,7 +60,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
     throw new Error('No store.json')
   }
 
-  const syncNotified = await syncNotifiedFile.read().once()
+  let notified = (await syncNotifiedFile.read().once())?.notified ?? false
 
   const conf = await lndConfFile.read().const(effects)
   if (!conf) {
@@ -279,13 +279,18 @@ export const main = sdk.setupMain(async ({ effects }) => {
       subcontainer: null,
       exec: {
         fn: async () => {
-          if (!syncNotified?.notified) {
+          // The SDK re-fires this oneshot every time sync-progress dips out
+          // of success and recovers (graph re-sync, transient lncli errors).
+          // The closure flag is the source of truth within a main lifecycle;
+          // the on-disk flag re-seeds it on next startup.
+          if (!notified) {
             await sdk.notification.create(effects, {
               level: 'success',
               title: i18n('Sync Complete'),
               message: i18n('LND is synced to chain and graph.'),
             })
             await syncNotifiedFile.write(effects, { notified: true })
+            notified = true
           }
           return null
         },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_20_1_beta_5 } from './v0.20.1.beta.5'
+import { v_0_20_1_beta_6 } from './v0.20.1.beta.6'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_20_1_beta_5,
+  current: v_0_20_1_beta_6,
   other: [],
 })

--- a/startos/versions/v0.20.1.beta.6.ts
+++ b/startos/versions/v0.20.1.beta.6.ts
@@ -13,14 +13,14 @@ type OldConfig = {
   }
 }
 
-export const v_0_20_1_beta_5 = VersionInfo.of({
-  version: '0.20.1-beta:5',
+export const v_0_20_1_beta_6 = VersionInfo.of({
+  version: '0.20.1-beta:6',
   releaseNotes: {
-    en_US: '- Updated to start-sdk 1.5.0.',
-    es_ES: '- Actualizado a start-sdk 1.5.0.',
-    de_DE: '- Aktualisierung auf start-sdk 1.5.0.',
-    pl_PL: '- Zaktualizowano do start-sdk 1.5.0.',
-    fr_FR: '- Mise à jour vers start-sdk 1.5.0.',
+    en_US: 'Fixes repeated "Sync Complete" notifications when LND briefly flickered out of and back into the synced state.',
+    es_ES: 'Corrige notificaciones repetidas de "Sincronización completa" cuando LND salía y volvía brevemente al estado sincronizado.',
+    de_DE: 'Behebt wiederholte „Sync Complete"-Benachrichtigungen, wenn LND kurzzeitig aus dem synchronisierten Zustand fiel und wieder hineinkam.',
+    pl_PL: 'Naprawia powtarzające się powiadomienia „Sync Complete", gdy LND chwilowo wypadał ze stanu zsynchronizowanego i do niego wracał.',
+    fr_FR: 'Corrige les notifications « Sync Complete » répétées lorsque LND sortait brièvement de l\'état synchronisé puis y revenait.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Users were getting repeated **Sync Complete** notifications after updating to the latest version.

`main.ts` reads `sync-notified.json` once at startup into a closure const. The `synced-true` oneshot checks against that snapshot. The SDK's `HealthDaemon` re-fires a oneshot every time its dependency dips out of `success` and recovers (`changeRunning(false)` → `changeRunning(true)` → `daemon.start()` re-enters the loop after the previous exit nulled it out). And `sync-progress` legitimately flickers: `info.synced_to_graph` flips back to `false` during graph updates, transient `lncli` failures return `'loading'`/`'failure'`. Each re-fire saw the stale startup snapshot and re-notified, even though the on-disk flag had already been written.

The earlier fix (#157, moving the flag out of `store.json` to stop the const-watch from restarting main) was correct, but it sealed in the captured-snapshot bug — with main no longer restarting, that snapshot never refreshes.

- Switch the snapshot to a mutable closure flag (`let notified`) updated alongside the disk write. Subsequent re-fires in the same main lifecycle see `notified === true` and skip.
- The on-disk flag still re-seeds the closure on next main startup, so the once-per-install guarantee survives main restarts.
- Bumps `0.20.1-beta:5` → `:6` (rename version file in place — no migration needed). README's claim that the notification "fires only once per install" stays accurate.

## Test plan

- [x] \`make\` builds both \`x86_64\` and \`aarch64\` cleanly (tsc, ncc, s9pk pack).
- [ ] Install on a node that's already synced — confirm a single **Sync Complete** notification fires, then doesn't re-fire when sync briefly flickers (e.g. force a graph re-sync, or restart bitcoind to cause a transient \`lncli\` failure).
- [ ] Restart LND after the flag is set — confirm no re-notification on the next sync.