### PR TITLE
fix: stop sync-progress health check spamming failures during startup

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -240,11 +240,24 @@ export const main = sdk.setupMain(async ({ effects }) => {
       ready: {
         display: i18n('Network and Graph Sync Progress'),
         fn: async () => {
-          const res = await lndSub.exec(
-            ['lncli', '--rpcserver=lnd.startos', 'getinfo'],
-            {},
-            30_000,
-          )
+          let res
+          try {
+            res = await lndSub.exec(
+              ['lncli', '--rpcserver=lnd.startos', 'getinfo'],
+              {},
+              30_000,
+            )
+          } catch {
+            // The LND subcontainer can be momentarily absent while main is
+            // re-running (e.g. Bitcoin Core's .cookie rotates on its restart,
+            // which tears down lnd-sub to rebuild it). With no PID 1 in the
+            // subcontainer, exec can't join its namespaces and throws a
+            // filesystem I/O error (".../proc/1/ns/pid: No such file or
+            // directory") instead of returning a result. Treat that as "still
+            // coming up" — the lnd daemon's own `ready` check reflects a
+            // genuine crash separately.
+            return { message: i18n('LND is starting…'), result: 'starting' }
+          }
           if (
             res.exitCode === 0 &&
             res.stdout !== '' &&
@@ -275,26 +288,19 @@ export const main = sdk.setupMain(async ({ effects }) => {
             }
           }
 
-          if (
-            res.stderr.includes(
-              'rpc error: code = Unknown desc = waiting to start',
-            )
-          ) {
-            return {
-              message: i18n('LND is starting…'),
-              result: 'starting',
-            }
-          }
-
-          if (res.exitCode === null) {
-            return {
-              message: i18n('Syncing to graph'),
-              result: 'loading',
-            }
-          }
+          // `lncli getinfo` only succeeds once LND's RPC server is fully
+          // active, so any non-zero (or null) exit here means LND is still
+          // coming up — e.g. the wallet isn't unlocked yet, or the RPC server
+          // reports "waiting to start" / "the RPC server is in the process of
+          // starting up". That exact wording varies by LND version, so rather
+          // than match a fixed string (the old check pinned "waiting to start"
+          // and missed 0.20's phrasing, surfacing hundreds of spurious
+          // failures per boot) we treat every non-success as a transient
+          // startup state. A genuine crash/outage is owned by the lnd daemon's
+          // `ready` check and the LND Server (/v1/state) health check.
           return {
-            message: `Error: ${res.stderr as string}`,
-            result: 'failure',
+            message: i18n('LND is starting…'),
+            result: 'starting',
           }
         },
       },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -17,18 +17,18 @@ type OldConfig = {
 }
 
 export const current = VersionInfo.of({
-  version: '0.20.1-beta:12',
+  version: '0.20.1-beta:13',
   releaseNotes: {
     en_US:
-      'Adds a hidden **Auto-Configure** action that lets a dependent service request specific lnd.conf settings through a one-click task. The first use is enabling onion messages for BOLT12 offers (e.g. BOLT12 Pay / LNDK).',
+      'Fixes the **Network and Graph Sync Progress** health check spuriously reporting a failure and flooding the logs while LND is still starting up — most visibly right after an upgrade, when Bitcoin Core is still loading. The check now reports **Starting** until LND is ready to answer.',
     es_ES:
-      'Añade una acción oculta **Configuración automática** que permite a un servicio dependiente solicitar ajustes específicos de lnd.conf mediante una tarea de un solo clic. Su primer uso es habilitar los mensajes onion para las ofertas BOLT12 (por ejemplo, BOLT12 Pay / LNDK).',
+      'Corrige el chequeo de estado **Progreso de sincronización de red y grafo** que reportaba erróneamente un fallo e inundaba los registros mientras LND aún se estaba iniciando — más visible justo después de una actualización, cuando Bitcoin Core todavía se está cargando. Ahora el chequeo indica **Iniciando** hasta que LND está listo para responder.',
     de_DE:
-      'Fügt eine versteckte Aktion **Automatisch konfigurieren** hinzu, mit der ein abhängiger Dienst bestimmte lnd.conf-Einstellungen über eine Ein-Klick-Aufgabe anfordern kann. Der erste Anwendungsfall ist das Aktivieren von Onion-Nachrichten für BOLT12-Angebote (z. B. BOLT12 Pay / LNDK).',
+      'Behebt einen Fehler, bei dem die Zustandsprüfung **Netzwerk- und Graph-Synchronisierungsfortschritt** fälschlicherweise einen Fehler meldete und die Protokolle überflutete, während LND noch startete — am deutlichsten direkt nach einer Aktualisierung, wenn Bitcoin Core noch lädt. Die Prüfung meldet jetzt **Startet**, bis LND antwortbereit ist.',
     pl_PL:
-      'Dodaje ukrytą akcję **Automatyczna konfiguracja**, która pozwala usłudze zależnej zażądać określonych ustawień lnd.conf za pomocą zadania jednym kliknięciem. Pierwszym zastosowaniem jest włączenie wiadomości onion dla ofert BOLT12 (np. BOLT12 Pay / LNDK).',
+      'Naprawia kontrolę stanu **Postęp synchronizacji sieci i grafu**, która błędnie zgłaszała awarię i zalewała logi, gdy LND wciąż się uruchamiał — najbardziej widoczne tuż po aktualizacji, gdy Bitcoin Core nadal się ładuje. Kontrola zgłasza teraz **Uruchamianie**, dopóki LND nie jest gotowy do odpowiedzi.',
     fr_FR:
-      "Ajoute une action masquée **Configuration automatique** qui permet à un service dépendant de demander des paramètres lnd.conf spécifiques via une tâche en un clic. Le premier usage est l'activation des messages onion pour les offres BOLT12 (par exemple BOLT12 Pay / LNDK).",
+      "Corrige le contrôle de santé **Progression de la synchronisation du réseau et du graphe** qui signalait à tort un échec et inondait les journaux pendant que LND démarrait encore — surtout juste après une mise à jour, lorsque Bitcoin Core est encore en cours de chargement. Le contrôle indique désormais **Démarrage** jusqu'à ce que LND soit prêt à répondre.",
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Problem

On a node upgrading from an earlier `0.20.1-beta` revision, the **Network and Graph Sync Progress** health check reported a hard `failure` and flooded the service logs (~1,300 lines in one ~20-minute window) while LND was still starting up. LND itself was healthy — it booted, synced, and routed normally — but the check showed red and spammed the log.

## Root cause

The check runs `lncli getinfo` inside the LND subcontainer on a loop. Two startup-window outcomes were mishandled:

1. **`exec` throws** a filesystem I/O error (`.../proc/1/ns/pid: No such file or directory`) when the subcontainer is momentarily absent — which happens while `main` is re-running. The throw was uncaught, so the check rejected and StartOS logged `Health Check sync-progress failed`.
2. **`getinfo` exits non-zero** with `the RPC server is in the process of starting up, but not yet ready to accept calls`. The code only matched the hardcoded string `waiting to start`, which LND 0.20 no longer emits, so it fell through to the `result: 'failure'` branch.

### Why it surfaced after an upgrade (and rarely)

`main` restarts whenever Bitcoin Core's `.cookie` changes (intended — LND needs the new cookie to re-auth). When a user updates **Bitcoin Core and then LND back-to-back**, Core's restart rotates the cookie while it's still loading, which tears down `lnd-sub` and restarts LND — and LND then sits in `Waiting for chain backend` for minutes while Core finishes loading. That stretched-out, restart-heavy window is what makes the always-present mishandling visible. Steady-state nodes never hit it, which is why it looked like a one-off.

## Fix

- Wrap the `exec` in `try/catch`; a momentarily-absent subcontainer now reports `Starting` instead of throwing.
- Treat **any** non-success `getinfo` as `Starting` rather than matching a version-specific string. `getinfo` only succeeds once RPC is fully active, so every other outcome is a transient startup state. Genuine down/crash is owned by the `lnd` daemon's `ready` check and the **LND Server** (`/v1/state`) check — not this one.

This changes only *reporting* during startup; LND's behavior is unchanged. The README already documents this check's states as *Synced / Syncing to chain / Syncing to graph / Starting* (no failure state), so code and docs now agree.

## Changes
- `startos/main.ts` — guard the exec; collapse the brittle string-match tail.
- `startos/versions/current.ts` — bump to `0.20.1-beta:13` with release notes (5 languages).

## Testing
- `npm run check` (tsc) passes.
- No new migration; bump is in-place per the repo's versioning guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)