### PR TITLE
fix: raise bolt→SQLite migration timeouts for large nodes

### DIFF
--- a/startos/sqliteBackend.ts
+++ b/startos/sqliteBackend.ts
@@ -40,10 +40,14 @@ const tlsCert = `${lndDataDir}/tls.cert`
 const lndUrl = `https://127.0.0.1:${restPort}`
 
 // LND reaches the wallet-unlocker (LOCKED) quickly, but applying the channeldb
-// schema migrations during unlock can take several minutes on a large node.
-const SCHEMA_TIMEOUT_MS = 30 * 60_000
-// Copying every bucket to SQLite is bounded by db size — generous backstop.
-const MIGRATE_TIMEOUT_MS = 30 * 60_000
+// schema migrations during unlock scales with db size — minutes on a small
+// node, far longer on a large one. Both values are pure backstops: on success
+// the chain resolves the instant it's ready, so a generous cap never slows a
+// healthy migration, it only keeps a large node from tripping the deadline.
+const SCHEMA_TIMEOUT_MS = 2 * 60 * 60_000
+// Copying every bucket to SQLite is bounded by db size; a multi-GB channel.db
+// on a busy routing node can take hours. Sized to outlast the largest nodes.
+const MIGRATE_TIMEOUT_MS = 6 * 60 * 60_000
 
 type LndState =
   | 'NON_EXISTING'

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,18 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.21.1-beta:1',
+  version: '0.21.1-beta:2',
   releaseNotes: {
-    en_US: 'Internal updates',
-    es_ES: 'Actualizaciones internas',
-    de_DE: 'Interne Aktualisierungen',
-    pl_PL: 'Aktualizacje wewnętrzne',
-    fr_FR: 'Mises à jour internes',
+    en_US:
+      'Raise the database migration timeout so large nodes can finish the SQLite conversion.',
+    es_ES:
+      'Aumenta el tiempo de espera de la migración de la base de datos para que los nodos grandes puedan completar la conversión a SQLite.',
+    de_DE:
+      'Erhöht das Zeitlimit der Datenbankmigration, damit große Nodes die SQLite-Konvertierung abschließen können.',
+    pl_PL:
+      'Zwiększa limit czasu migracji bazy danych, aby duże węzły mogły ukończyć konwersję do SQLite.',
+    fr_FR:
+      'Augmente le délai d’expiration de la migration de la base de données afin que les grands nœuds puissent terminer la conversion vers SQLite.',
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

The 0.21 bolt→SQLite migration ran each phase under a single **30-minute** `runUntilSuccess` wall-clock deadline. On a large node the size-bound copy phase (`lndinit migrate-db` over a multi-GB `channel.db`) can exceed that, tripping the timeout — and because the migration is a resumable init step, it just loops against the same wall each retry without ever finishing. Hit in the wild on a real server.

Raise the backstops in `startos/sqliteBackend.ts`:

| Phase | Const | Before | After |
|---|---|---|---|
| Schema finalize (LND applies channeldb schema migrations on unlock) | `SCHEMA_TIMEOUT_MS` | 30 min | **2 h** |
| Bucket copy (`lndinit migrate-db` → SQLite) | `MIGRATE_TIMEOUT_MS` | 30 min | **6 h** |

`runUntilSuccess(timeout)` arms one `setTimeout` that rejects the whole chain if it fires; the chain otherwise resolves the instant every daemon/oneshot is ready. So these are pure backstops — a generous cap never slows a healthy migration, it only stops a large node tripping the deadline. Bumped to `0.21.1-beta:2`.

Recovery for an already-timed-out node: the migration is resumable (`dbSchemaFinalized` / `dbMigrationComplete` startup-flags), so installing this revision lets the stuck run continue from where it left off — no restart, no data loss.

## Test plan

1. On a StartOS box, install an LND node still on the bolt backend (pre-0.21) with a wallet and at least one channel.
2. Update to this build (`0.21.1-beta:2`). Watch the init progress UI show the **Finalizing database schema** then **Copying database to SQLite** phases.
3. Confirm the migration completes, `channel.sqlite` appears under `data/graph/mainnet/`, and LND starts and reaches synced/active with channels intact.
4. Regression on the fast path: fresh install (born on SQLite) and a normal restart of an already-migrated node both skip the migration (no phases shown) and start normally.
5. Optional (large-node behavior): a node whose copy phase runs past 30 min now completes instead of erroring at the old deadline.