### PR TITLE
fix: don't restart LND when bitcoind's cookie disappears

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -112,10 +112,14 @@ export const main = sdk.setupMain(async ({ effects }) => {
     'lnd-sub',
   )
 
-  // Restart if Bitcoin .cookie changes
+  // Restart only when bitcoind writes a replacement cookie — an absent cookie
+  // means bitcoind is down, and stopping LND then hangs its shutdown.
   if (useBitcoind) {
     await FileHelper.string(`${await lndSub.rootfs}${bitcoindMnt}/.cookie`)
-      .read()
+      .read(
+        (cookie) => cookie,
+        (prev, next) => next === null || prev === next,
+      )
       .const(effects)
   }
 

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,63 +1,43 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.21.1-beta:6',
+  version: '0.21.1-beta:7',
   releaseNotes: {
-    en_US: `Puts the **REST** connection back behind StartOS-managed TLS. gRPC is unchanged.
+    en_US: `Fixes LND being force-stopped every time Bitcoin Core restarts.
 
-**REST wallets connect without turning off certificate checks**
-- StartOS serves REST on port 8080 with your server's own certificate — the one your device already trusts through the StartOS Root CA, or your Let's Encrypt certificate if you use a custom domain. Wallets such as Zeus connect with certificate validation left on.
-- LND's certificate no longer travels inside the REST connection string, so its pairing QR code is small enough to display and scan again.
+**LND now waits for Bitcoin Core to come back before reloading**
+- LND reloads whenever Bitcoin Core issues new RPC credentials, which it does on every restart. That reload used to be triggered the moment Bitcoin Core *began* shutting down — while its RPC was already unreachable — so LND could not finish its own shutdown and was force-stopped after 60 seconds.
+- LND now ignores the credentials disappearing and reloads only once Bitcoin Core is back up and has published new ones, so it stops cleanly and restarts against a working connection.
 
-**⚠️ Re-pair REST wallets after updating**
-- The REST port and certificate both change, so REST connection details saved from the previous version will not reconnect. Open the **REST LND Connect** interface and scan the new code. gRPC connections are unaffected.
+Channels and funds were never at risk: LND's databases are built to survive an abrupt stop. A clean shutdown simply avoids the recovery work an abrupt one leaves behind.`,
+    es_ES: `Corrige que LND se detuviera a la fuerza cada vez que Bitcoin Core se reiniciaba.
 
-**⚠️ Services using LND's REST API need their own update**
-- LNbits, Ride The Lightning and BOLT12 Pay look up LND's REST address in a way that stops resolving here, and will report LND as unreachable until each of them is updated. Nothing about the connection itself changes for them — only how they find the port. Services that use gRPC are unaffected.`,
-    es_ES: `Devuelve la conexión **REST** al TLS gestionado por StartOS. gRPC no cambia.
+**LND ahora espera a que Bitcoin Core vuelva antes de recargarse**
+- LND se recarga cuando Bitcoin Core emite nuevas credenciales RPC, algo que hace en cada reinicio. Esa recarga se activaba en el momento en que Bitcoin Core *empezaba* a apagarse — cuando su RPC ya era inalcanzable —, así que LND no podía completar su propio apagado y se detenía a la fuerza a los 60 segundos.
+- Ahora LND ignora la desaparición de las credenciales y se recarga solo cuando Bitcoin Core ha vuelto y ha publicado unas nuevas, de modo que se detiene limpiamente y arranca con una conexión operativa.
 
-**Los monederos REST se conectan sin desactivar la validación de certificados**
-- StartOS sirve REST en el puerto 8080 con el certificado propio de tu servidor: el que tu dispositivo ya considera de confianza a través de la CA raíz de StartOS, o tu certificado de Let's Encrypt si usas un dominio propio. Monederos como Zeus se conectan con la validación de certificados activada.
-- El certificado de LND ya no viaja dentro de la cadena de conexión REST, así que su código QR de emparejamiento vuelve a ser lo bastante pequeño como para mostrarse y escanearse.
+Los canales y los fondos nunca estuvieron en riesgo: las bases de datos de LND están hechas para sobrevivir a una parada abrupta. Un apagado limpio simplemente evita el trabajo de recuperación que deja una parada abrupta.`,
+    de_DE: `Behebt, dass LND bei jedem Neustart von Bitcoin Core zwangsweise beendet wurde.
 
-**⚠️ Vuelve a emparejar los monederos REST tras actualizar**
-- El puerto y el certificado REST cambian, por lo que los datos de conexión REST guardados de la versión anterior no volverán a conectar. Abre la interfaz **REST LND Connect** y escanea el nuevo código. Las conexiones gRPC no se ven afectadas.
+**LND wartet jetzt auf die Rückkehr von Bitcoin Core, bevor es neu lädt**
+- LND lädt neu, sobald Bitcoin Core neue RPC-Zugangsdaten ausgibt — was bei jedem Neustart geschieht. Dieses Neuladen wurde bisher in dem Moment ausgelöst, in dem Bitcoin Core mit dem Herunterfahren *begann* — während dessen RPC bereits nicht mehr erreichbar war. LND konnte sein eigenes Herunterfahren daher nicht abschließen und wurde nach 60 Sekunden zwangsweise beendet.
+- LND ignoriert nun das Verschwinden der Zugangsdaten und lädt erst neu, wenn Bitcoin Core wieder läuft und neue veröffentlicht hat. So fährt es sauber herunter und startet mit einer funktionierenden Verbindung.
 
-**⚠️ Los servicios que usan la API REST de LND necesitan su propia actualización**
-- LNbits, Ride The Lightning y BOLT12 Pay localizan la dirección REST de LND de una forma que aquí deja de resolverse, y mostrarán LND como inaccesible hasta que cada uno se actualice. La conexión en sí no cambia para ellos: solo cómo encuentran el puerto. Los servicios que usan gRPC no se ven afectados.`,
-    de_DE: `Stellt die **REST**-Verbindung wieder auf das von StartOS verwaltete TLS um. gRPC bleibt unverändert.
+Kanäle und Guthaben waren nie gefährdet: Die Datenbanken von LND sind darauf ausgelegt, einen abrupten Stopp zu überstehen. Ein sauberes Herunterfahren erspart lediglich die Wiederherstellungsarbeit, die ein abrupter Stopp hinterlässt.`,
+    pl_PL: `Naprawia wymuszone zatrzymywanie LND przy każdym restarcie Bitcoin Core.
 
-**REST-Wallets verbinden sich ohne abgeschaltete Zertifikatsprüfung**
-- StartOS bedient REST auf Port 8080 mit dem eigenen Zertifikat Ihres Servers — dem, dem Ihr Gerät über die StartOS-Root-CA bereits vertraut, oder Ihrem Let's-Encrypt-Zertifikat, wenn Sie eine eigene Domain nutzen. Wallets wie Zeus verbinden sich mit aktivierter Zertifikatsprüfung.
-- Das Zertifikat von LND steckt nicht mehr in der REST-Verbindungszeichenfolge, sodass deren Kopplungs-QR-Code wieder klein genug ist, um angezeigt und gescannt zu werden.
+**LND czeka teraz na powrót Bitcoin Core, zanim się przeładuje**
+- LND przeładowuje się, gdy Bitcoin Core wydaje nowe dane uwierzytelniające RPC, co robi przy każdym restarcie. Dotąd to przeładowanie uruchamiało się w chwili, gdy Bitcoin Core *zaczynał* się wyłączać — a jego RPC było już nieosiągalne — więc LND nie mogło dokończyć własnego wyłączania i po 60 sekundach było zatrzymywane siłą.
+- Teraz LND ignoruje zniknięcie danych uwierzytelniających i przeładowuje się dopiero wtedy, gdy Bitcoin Core wróci i opublikuje nowe. Dzięki temu zatrzymuje się czysto i startuje z działającym połączeniem.
 
-**⚠️ Koppeln Sie REST-Wallets nach dem Update neu**
-- REST-Port und -Zertifikat ändern sich, daher verbinden sich gespeicherte REST-Verbindungsdaten der vorherigen Version nicht mehr. Öffnen Sie die Schnittstelle **REST LND Connect** und scannen Sie den neuen Code. gRPC-Verbindungen sind nicht betroffen.
+Kanały i środki nigdy nie były zagrożone: bazy danych LND są zaprojektowane tak, by przetrwać nagłe zatrzymanie. Czyste wyłączenie po prostu oszczędza pracy naprawczej, którą zostawia po sobie nagłe.`,
+    fr_FR: `Corrige l'arrêt forcé de LND à chaque redémarrage de Bitcoin Core.
 
-**⚠️ Dienste, die LNDs REST-API nutzen, brauchen ihr eigenes Update**
-- LNbits, Ride The Lightning und BOLT12 Pay ermitteln die REST-Adresse von LND auf eine Weise, die hier nicht mehr auflöst, und melden LND als nicht erreichbar, bis jeder von ihnen aktualisiert wurde. An der Verbindung selbst ändert sich für sie nichts — nur daran, wie sie den Port finden. Dienste, die gRPC nutzen, sind nicht betroffen.`,
-    pl_PL: `Przywraca połączenie **REST** do TLS zarządzanego przez StartOS. gRPC pozostaje bez zmian.
+**LND attend désormais le retour de Bitcoin Core avant de se recharger**
+- LND se recharge lorsque Bitcoin Core émet de nouveaux identifiants RPC, ce qu'il fait à chaque redémarrage. Ce rechargement était jusqu'ici déclenché au moment où Bitcoin Core *commençait* à s'arrêter — alors que son RPC était déjà injoignable —, si bien que LND ne pouvait pas terminer son propre arrêt et était arrêté de force au bout de 60 secondes.
+- LND ignore maintenant la disparition des identifiants et ne se recharge qu'une fois Bitcoin Core revenu et de nouveaux identifiants publiés. Il s'arrête donc proprement et redémarre sur une connexion fonctionnelle.
 
-**Portfele REST łączą się bez wyłączania weryfikacji certyfikatu**
-- StartOS obsługuje REST na porcie 8080 własnym certyfikatem serwera — tym, któremu Twoje urządzenie już ufa dzięki głównemu CA StartOS, albo Twoim certyfikatem Let's Encrypt, jeśli używasz własnej domeny. Portfele takie jak Zeus łączą się z włączoną weryfikacją certyfikatu.
-- Certyfikat LND nie jest już przenoszony w ciągu połączenia REST, więc jego kod QR do parowania znów jest na tyle mały, że da się go wyświetlić i zeskanować.
-
-**⚠️ Po aktualizacji sparuj ponownie portfele REST**
-- Port i certyfikat REST się zmieniają, więc dane połączenia REST zapisane z poprzedniej wersji nie połączą się ponownie. Otwórz interfejs **REST LND Connect** i zeskanuj nowy kod. Połączenia gRPC pozostają bez zmian.
-
-**⚠️ Usługi korzystające z API REST LND wymagają własnej aktualizacji**
-- LNbits, Ride The Lightning i BOLT12 Pay ustalają adres REST LND w sposób, który przestaje tu działać, i będą zgłaszać LND jako nieosiągalny, dopóki każda z nich nie zostanie zaktualizowana. Samo połączenie się dla nich nie zmienia — zmienia się tylko sposób znajdowania portu. Usługi korzystające z gRPC pozostają nietknięte.`,
-    fr_FR: `Replace la connexion **REST** derrière le TLS géré par StartOS. gRPC est inchangé.
-
-**Les portefeuilles REST se connectent sans désactiver la validation du certificat**
-- StartOS sert REST sur le port 8080 avec le certificat propre à votre serveur — celui auquel votre appareil fait déjà confiance via l'autorité racine StartOS, ou votre certificat Let's Encrypt si vous utilisez un domaine personnalisé. Des portefeuilles comme Zeus se connectent avec la validation du certificat activée.
-- Le certificat de LND ne circule plus dans la chaîne de connexion REST, si bien que son QR code d'appairage est de nouveau assez petit pour être affiché et scanné.
-
-**⚠️ Réappairez les portefeuilles REST après la mise à jour**
-- Le port et le certificat REST changent : les informations de connexion REST enregistrées avec la version précédente ne se reconnecteront pas. Ouvrez l'interface **REST LND Connect** et scannez le nouveau code. Les connexions gRPC ne sont pas concernées.
-
-**⚠️ Les services utilisant l'API REST de LND nécessitent leur propre mise à jour**
-- LNbits, Ride The Lightning et BOLT12 Pay déterminent l'adresse REST de LND d'une manière qui cesse de se résoudre ici, et signaleront LND comme injoignable tant que chacun n'aura pas été mis à jour. La connexion elle-même ne change pas pour eux — seulement la façon dont ils trouvent le port. Les services utilisant gRPC ne sont pas concernés.`,
+Les canaux et les fonds n'ont jamais été en danger : les bases de données de LND sont conçues pour survivre à un arrêt brutal. Un arrêt propre évite simplement le travail de récupération qu'un arrêt brutal laisse derrière lui.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Problem

LND was SIGKILLed on every Bitcoin Core restart.

Bitcoin Core deletes its `.cookie` on clean shutdown. `FileHelper`'s watch generator yields `null` for a missing file, and `Watchable.watchGen` emits on any inequality — so `.read().const(effects)` fired `constRetry()` the moment bitcoind *began* stopping, rather than when it came back with new credentials.

That restarted main, and so SIGTERM'd LND, at the one moment its chain backend was guaranteed unreachable. LND blocked in shutdown on the dead RPC and was force-killed after the SDK's `DEFAULT_SIGTERM_TIMEOUT` (60s):

```
17:31:34.870  CHBU: chanbackup.SubSwapper shutting down...
17:32:03.641  LNWL: ...getpeerinfo... 10.0.3.1:50116: connection refused
17:32:34      Error: lnd exited with signal SIGKILL
```

`LTND: Shutdown complete` never appears. With bitcoind up, the same node stops cleanly in ~1 second — the 60s timeout was never the issue, and raising it would only have delayed the kill.

## Fix

Pass an `eq` that treats an absent cookie as "no change". `prev` retains the old cookie, so the restart fires only once bitcoind is back and has written a fresh one.

The identity `map` is there only because `read()` has no eq-only overload (`fileHelper.ts:346`) — worth an SDK follow-up.

## Scope

The same `.read().const(effects)` cookie pattern is in `cln-startos`, `datum-gateway-startos`, `electrs-startos` and `fedimint-guardian-startos`; companion PRs cover those.

## Test plan

1. Install this s9pk with Bitcoin Core as the backend and let LND reach **Synced to chain and graph**.
2. Restart Bitcoin Core.
3. In LND's logs, confirm:
   - LND is **not** torn down while bitcoind is stopping (no shutdown sequence beginning before bitcoind is back).
   - When it does reload, the shutdown ends with `LTND: Shutdown complete` and there is **no** `Error: lnd exited with signal SIGKILL`.
4. Confirm LND reconnects and returns to **Synced to chain and graph**.
5. Stop LND directly (`start-cli package stop lnd`) with bitcoind running and confirm it still exits cleanly in ~1s.
6. Regression: confirm LND still picks up rotated credentials — after step 2 it should be authenticating with bitcoind's new cookie, not the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)