### PR TITLE
fix: point tor.dns at the OS resolver so fresh nodes can bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ You don't have to use the actions — you can edit `lnd.conf` by hand, and your 
 
 - `externalip` / `externalhosts` — rebuilt by `watchHosts` from the Peer interface's addresses plus the **Custom External Host** action
 - `tor.socks` — set by `watchTorSocks` to the Tor SOCKS proxy's LXC-bridge address (`10.0.3.1:9050`); always written (the bridge address is constant whether or not Tor is installed, so LND never restarts on Tor churn — LND only dials the proxy when Tor is enabled, and a dead address is just connection-refused)
+- `tor.dns` — set by `watchTorDns` to the OS resolver (`10.0.3.1:53`); written like `tor.socks` in every mode except tor-only, where it is cleared. See [DNS-seed bootstrapping under Tor](#dns-seed-bootstrapping-under-tor)
 - the Bitcoin backend keys (`bitcoin.node`, `bitcoind.rpchost`, `bitcoind.rpccookie`, `bitcoind.zmqpubrawblock`, `bitcoind.zmqpubrawtx`, `fee.url`) — re-applied by `main` from the selected backend
 
 The fixed keys in the table above are likewise reset to their pinned values, `rpcuser`/`rpcpass` are stripped (cookie auth only), and **comments are not retained** — the file is rewritten from its parsed settings.
@@ -361,11 +362,31 @@ LND can alternatively use **Neutrino** (built-in light client) with no Bitcoin d
 
 Tor is likewise a marketplace service, not built into StartOS. It provides LND's outbound SOCKS proxy and the onion services used for inbound reachability, and becomes a required _running_ dependency whenever **Enable Tor** is on.
 
+### DNS-seed bootstrapping under Tor
+
+A node with no channels and no graph has only two ways to find a first peer: sample the channel graph, or resolve the BOLT-10 DNS seeds. The first is circular on a fresh install — the graph it would sample is the graph it hasn't downloaded — which leaves the seeds, and those need an SRV lookup.
+
+SOCKS5 can't carry an SRV query, so with `tor.active` LND doesn't use the system resolver for it — `tor.LookupSRV` dials `tor.dns` over TCP itself. That collides with the StartOS **egress guard**, which drops container traffic to port 53 off the LXC bridge (`inet startos_egress_guard`, in `start-core`'s base nftables ruleset) — services are expected to resolve through the OS proxy at `10.0.3.1:53`, a host-local input-hook destination the guard never sees. LND's built-in `tor.dns` default is a public nameserver (`soa.nodes.lightning.directory:53`), and with **Skip for clearnet peers** on that dial goes out direct, into the guard. The rule is a `drop`, not a `reject`, so nothing comes back: the connection sits in `SYN_SENT` until LND's own timeout and every bootstrap round logs `Unable to retrieve initial bootstrap peers: no addresses found`. The node stays at zero peers and `synced_to_graph` never goes true.
+
+`watchTorDns` sets `tor.dns` to the OS resolver so the query stays on the bridge. Like `tor.socks` it is written in every mode but one:
+
+| Mode                                   | `tor.dns`   | Why                                                                                                                                                                                                     |
+| -------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tor on, **Skip for clearnet peers** on | OS resolver | The affected path — the dial goes out direct, so it must target a resolver the guard doesn't drop                                                                                                       |
+| Tor on, tor-only                       | unset       | LND's `dialProxy` bypasses SOCKS only under `skipProxyForClearNetTargets`, so here the dial is proxied and no exit would reach an RFC1918 address. Unaffected anyway: it goes to the SOCKS port, not 53 |
+| Tor off                                | OS resolver | Parsed but never dialed — `ProxyNet` is only built under `tor.active`. Inert, as `tor.socks` is in this mode                                                                                            |
+
+Two things to know before editing this. The value must be `host:port` — LND documents the flag that way, and while a bare host picks up `:53` from `verifyPort`, writing it explicitly matches the form of the default. And the key is normalized on **every** start regardless of `tor.active` (LND's `ParseAddressString` call sits above the `if cfg.Tor.Active` block in `config.go`), so whatever is written must always parse; an unresolvable value would abort startup even with Tor off.
+
+Note this is only about how LND finds the seeds. With Tor off, DNS is unremarkable — the Go resolver follows `/etc/resolv.conf` to `10.0.3.1`, an input-hook destination the forward-hook guard never sees.
+
+This only ever bit nodes bootstrapping from nothing. Once the graph is populated the graph bootstrapper carries the node on its own, which is why an established node never showed the symptom.
+
 ## Limitations and Differences
 
 1. **Mainnet only** — testnet/regtest/signet are not available
 2. **No `lncli create` or `lncli unlock`** — wallet lifecycle is fully automated by StartOS
-3. **A few `lnd.conf` keys are StartOS-managed** — `externalip`/`externalhosts`, `tor.socks`, and the Bitcoin backend connection keys are re-derived on every start, so hand-edits to _those_ keys don't stick (use the corresponding action). Every other setting you put in `lnd.conf` is preserved across restarts — see [Editing `lnd.conf` directly](#editing-lndconf-directly)
+3. **A few `lnd.conf` keys are StartOS-managed** — `externalip`/`externalhosts`, `tor.socks`, `tor.dns`, and the Bitcoin backend connection keys are re-derived on every start, so hand-edits to _those_ keys don't stick (use the corresponding action). Every other setting you put in `lnd.conf` is preserved across restarts — see [Editing `lnd.conf` directly](#editing-lndconf-directly)
 4. **Bitcoin cookie auth only** — `rpcuser`/`rpcpass` are explicitly removed; authentication uses the mounted `.cookie` file
 5. **"Enable Tor" affects outbound only** — Tor is not built into StartOS; it is a marketplace service. The Tor Settings toggle controls whether LND's _outbound_ peer dials use the Tor proxy. It does not create inbound reachability: that comes from adding an onion service to the Peer interface (via the Tor service), and once added it works independently of this toggle. Without the Tor service installed, neither outbound nor inbound Tor is available.
 6. **Restored nodes should not be reused** — after backup restore, sweep funds and reinstall

--- a/startos/fileModels/lnd.conf.ts
+++ b/startos/fileModels/lnd.conf.ts
@@ -147,6 +147,7 @@ export const shape = z.object({
   // ──── Tor ────
   'tor.active': z.boolean().catch(true),
   'tor.socks': iniString,
+  'tor.dns': iniString,
   'tor.skip-proxy-for-clearnet-targets': iniBoolean.transform((v) => v ?? true),
 
   // ──── Watchtower ────

--- a/startos/init/index.ts
+++ b/startos/init/index.ts
@@ -9,6 +9,7 @@ import { seedFiles } from './seedFiles'
 import { setupCerts } from './setupCerts'
 import { tasksOnInstall } from './tasksOnInstall'
 import { watchHosts } from './watchHosts'
+import { watchTorDns } from './watchTorDns'
 import { watchTorSocks } from './watchTorSocks'
 
 export const init = sdk.setupInit(
@@ -22,6 +23,7 @@ export const init = sdk.setupInit(
   migrateSqlite,
   watchHosts,
   watchTorSocks,
+  watchTorDns,
   tasksOnInstall,
 )
 

--- a/startos/init/watchTorDns.ts
+++ b/startos/init/watchTorDns.ts
@@ -1,0 +1,27 @@
+import { lndConfFile } from '../fileModels/lnd.conf'
+import { sdk } from '../sdk'
+
+export const watchTorDns = sdk.setupOnInit(async (effects) => {
+  // Under `tor.active` LND resolves the DNS seeds itself — SOCKS5 can't carry
+  // an SRV query — dialing `tor.dns` over TCP instead of the system resolver.
+  // Its public default is unreachable here: the StartOS egress guard drops
+  // container traffic to port 53 off the bridge, leaving the OS proxy as the
+  // one resolver still routable (input hook, not forward).
+  //
+  // Not for tor-only, where it would break the lookup rather than fix it —
+  // tor's dialProxy bypasses the SOCKS proxy only under
+  // `skipProxyForClearNetTargets`, and no exit will reach an RFC1918 address.
+  // That mode dials the SOCKS port rather than port 53, so it never had the
+  // problem. Written in every other mode, as `tor.socks` is.
+  const skipClearnet = await lndConfFile
+    .read((c) => c['tor.skip-proxy-for-clearnet-targets'] !== false)
+    .const(effects)
+
+  await lndConfFile.merge(
+    effects,
+    {
+      'tor.dns': skipClearnet ? `${await sdk.getOsIp(effects)}:53` : undefined,
+    },
+    { allowWriteAfterConst: true },
+  )
+})

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,33 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.21.1-beta:8',
+  version: '0.21.1-beta:9',
   releaseNotes: {
-    en_US: `Corrects the Bitcoin version requirement this service displays.
+    en_US: `Fixes a new node never finding its first peer while Tor is enabled.
 
-LND declared its Bitcoin requirement in a form that rendered as "must be below 29", which was never true — LND works with every current major version of Bitcoin. The requirement now reads as intended: Bitcoin 28.4:17 or newer.
+With Tor on and "Skip for clearnet peers" left at its default, LND looked up the Lightning DNS seeds by querying a public nameserver directly — traffic StartOS blocks, because services are expected to resolve through the OS. The lookup was dropped silently, so it timed out on every attempt. A node with no channels and no network graph yet has nothing else to find a peer from, so it sat at zero peers and never left "Syncing to graph". LND now sends that lookup to the StartOS resolver.
 
-If your Bitcoin service is older than 28.4:17, update it before updating LND.`,
-    es_ES: `Corrige el requisito de versión de Bitcoin que muestra este servicio.
+Established nodes were never affected: once the network graph is populated, LND finds peers from the graph itself. If your node has been stuck syncing, updating resolves it — no other action needed.`,
+    es_ES: `Corrige que un nodo nuevo nunca encontrara su primer par con Tor activado.
 
-LND declaraba su requisito de Bitcoin de una forma que se mostraba como «debe ser inferior a 29», algo que nunca fue cierto: LND funciona con todas las versiones principales actuales de Bitcoin. El requisito ahora se lee tal y como se pretendía: Bitcoin 28.4:17 o posterior.
+Con Tor activado y «Omitir para pares de clearnet» en su valor predeterminado, LND consultaba las semillas DNS de Lightning directamente a un servidor de nombres público: tráfico que StartOS bloquea, porque se espera que los servicios resuelvan a través del sistema operativo. La consulta se descartaba en silencio, así que expiraba en cada intento. Un nodo sin canales y sin grafo de red todavía no tiene ninguna otra forma de encontrar un par, por lo que se quedaba con cero pares y nunca salía de «Sincronizando con el grafo». Ahora LND dirige esa consulta al resolutor de StartOS.
 
-Si tu servicio Bitcoin es anterior a 28.4:17, actualízalo antes de actualizar LND.`,
-    de_DE: `Korrigiert die von diesem Dienst angezeigte Bitcoin-Versionsanforderung.
+Los nodos ya establecidos nunca se vieron afectados: una vez poblado el grafo de red, LND encuentra pares a partir del propio grafo. Si tu nodo estaba atascado sincronizando, actualizar lo resuelve; no hace falta nada más.`,
+    de_DE: `Behebt, dass ein neuer Knoten bei aktiviertem Tor nie seinen ersten Peer fand.
 
-LND gab seine Bitcoin-Anforderung in einer Form an, die als „muss kleiner als 29 sein“ dargestellt wurde — was nie zutraf: LND funktioniert mit allen aktuellen Hauptversionen von Bitcoin. Die Anforderung lautet nun wie beabsichtigt: Bitcoin 28.4:17 oder neuer.
+Mit aktiviertem Tor und „Für Clearnet-Peers überspringen“ in der Standardeinstellung fragte LND die Lightning-DNS-Seeds direkt bei einem öffentlichen Nameserver ab — Datenverkehr, den StartOS blockiert, da Dienste über das Betriebssystem auflösen sollen. Die Abfrage wurde stillschweigend verworfen und lief daher bei jedem Versuch in einen Timeout. Ein Knoten ohne Kanäle und noch ohne Netzwerkgraph hat keine andere Möglichkeit, einen Peer zu finden, blieb also bei null Peers und verließ „Synchronisiere Graph“ nie. LND richtet diese Abfrage jetzt an den StartOS-Resolver.
 
-Wenn dein Bitcoin-Dienst älter als 28.4:17 ist, aktualisiere ihn, bevor du LND aktualisierst.`,
-    pl_PL: `Poprawia wymóg wersji Bitcoina wyświetlany przez tę usługę.
+Etablierte Knoten waren nie betroffen: Sobald der Netzwerkgraph gefüllt ist, findet LND Peers über den Graphen selbst. Wenn dein Knoten beim Synchronisieren feststeckte, behebt das Update dies — weitere Schritte sind nicht nötig.`,
+    pl_PL: `Naprawia sytuację, w której nowy węzeł nigdy nie znajdował swojego pierwszego peera przy włączonym Torze.
 
-LND deklarował swój wymóg dotyczący Bitcoina w formie, która wyświetlała się jako „musi być niższa niż 29”, co nigdy nie było prawdą — LND działa ze wszystkimi aktualnymi głównymi wersjami Bitcoina. Wymóg brzmi teraz zgodnie z zamierzeniem: Bitcoin 28.4:17 lub nowszy.
+Przy włączonym Torze i domyślnym ustawieniu „Pomiń dla peerów clearnet” LND odpytywał seedy DNS sieci Lightning bezpośrednio z publicznego serwera nazw — ruch, który StartOS blokuje, ponieważ usługi mają rozwiązywać nazwy przez system operacyjny. Zapytanie było po cichu odrzucane, więc przy każdej próbie wygasało. Węzeł bez kanałów i bez grafu sieci nie ma żadnego innego sposobu na znalezienie peera, więc pozostawał z zerową liczbą peerów i nigdy nie opuszczał stanu „Synchronizacja z grafem”. LND kieruje teraz to zapytanie do resolvera StartOS.
 
-Jeśli twoja usługa Bitcoin jest starsza niż 28.4:17, zaktualizuj ją przed aktualizacją LND.`,
-    fr_FR: `Corrige l'exigence de version de Bitcoin affichée par ce service.
+Działające już węzły nigdy nie były dotknięte tym problemem: gdy graf sieci jest wypełniony, LND znajduje peerów na jego podstawie. Jeśli twój węzeł utknął na synchronizacji, aktualizacja to naprawi — nic więcej nie trzeba robić.`,
+    fr_FR: `Corrige le fait qu'un nouveau nœud ne trouvait jamais son premier pair lorsque Tor est activé.
 
-LND déclarait son exigence Bitcoin sous une forme qui s'affichait comme « doit être inférieure à 29 », ce qui n'a jamais été vrai : LND fonctionne avec toutes les versions majeures actuelles de Bitcoin. L'exigence s'affiche désormais comme prévu : Bitcoin 28.4:17 ou plus récent.
+Avec Tor activé et « Ignorer pour les pairs clearnet » laissé à sa valeur par défaut, LND interrogeait les seeds DNS de Lightning directement auprès d'un serveur de noms public — un trafic que StartOS bloque, car les services doivent résoudre via le système d'exploitation. La requête était abandonnée silencieusement et expirait donc à chaque tentative. Un nœud sans canaux et sans graphe de réseau n'a aucun autre moyen de trouver un pair : il restait à zéro pair et ne quittait jamais « Synchronisation du graphe ». LND adresse désormais cette requête au résolveur de StartOS.
 
-Si votre service Bitcoin est antérieur à 28.4:17, mettez-le à jour avant de mettre à jour LND.`,
+Les nœuds déjà établis n'ont jamais été concernés : une fois le graphe de réseau rempli, LND trouve ses pairs à partir du graphe lui-même. Si votre nœud était bloqué en synchronisation, la mise à jour le corrige — aucune autre action n'est nécessaire.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Problem

A fresh LND install with Tor enabled never finds a peer. It sits at zero peers with `synced_to_graph` false indefinitely — the UI's **Syncing to graph** — while the chain backend stays fully synced. Seen on the dev box: 21 hours, zero peers, failing identically from the first bootstrap attempt onward.

Only two bootstrappers can find a first peer:

1. **Authenticated Channel Graph** — samples the channel graph. Circular on a fresh install: the graph it would sample is the graph LND hasn't downloaded. Confirmed empty on the box — `graph_nodes = 1` (its own), `graph_channels = 0`, `graph_node_addresses = 0`.
2. **DNS seeds (BOLT-10)** — needs an SRV lookup. This is the one that has to work, and it doesn't.

SOCKS5 can't carry an SRV query, so under `tor.active` LND doesn't use the system resolver — `tor.LookupSRV` dials `tor.dns` over TCP itself. `tor.dns` was never set, so LND used its compiled-in default, `soa.nodes.lightning.directory:53`. With `tor.skip-proxy-for-clearnet-targets` on (the package default) that dial goes out **direct** rather than through the proxy, straight into `start-core`'s egress guard (`net/startos-base.nft`):

```
iifname "lxcbr0" meta l4proto { tcp, udp } th dport 53 drop
```

It's a `drop`, not a `reject`, so nothing comes back. On the box the socket sat in `SYN-SENT` to `104.131.26.124:53` — that default, resolved — while every bootstrap round logged:

```
[ERR] SRVR: Unable to retrieve initial bootstrap peers: no addresses found
```

Meanwhile the OS resolver answers the exact query LND needed: `SRV nodes.lightning.wiki` over TCP to `10.0.3.1` returns 8 records. LND simply never asked it. The second seed, `lseed.bitcoinstats.com`, is dead and SERVFAILs globally, so there was no fallback.

Established nodes were never affected — once the graph is populated the graph bootstrapper is self-sustaining, which is why this only surfaces on a fresh install.

## Fix

`watchTorDns` writes `tor.dns` as the OS resolver, keeping the query on the bridge where it's an input-hook destination the guard never inspects.

| Mode | `tor.dns` | Why |
| --- | --- | --- |
| Tor on, **Skip for clearnet peers** on | OS resolver | The affected path — dial goes out direct, so it must target a resolver the guard doesn't drop |
| Tor on, tor-only | unset | Would break the lookup rather than fix it (below) |
| Tor off | OS resolver | Parsed but never dialed |

**Why tor-only is excluded.** Verified against LND at `2b87887`, the exact `rev=2b8788` the box was running. `tor/tor.go`'s `dialProxy` dials direct *only* inside its `skipProxyForClearNetTargets` branch:

```go
clearDialer := &net.Dialer{Timeout: timeout}
if skipProxyForClearNetTargets {
    host, _, err := net.SplitHostPort(address)
    ...
    if !IsOnionHost(host) {
        return clearDialer.Dial("tcp", address)
    }
}
// Establish the connection through Tor's SOCKS proxy.
dialer, err := proxy.SOCKS5("tcp", socksAddr, auth, clearDialer)
```

With the flag off the SRV lookup falls through to SOCKS5, so no exit would reach an RFC1918 address — setting it there turns a working path into a broken one. That mode never had the bug either: being proxied, its dial goes to the SOCKS port, not port 53.

**Two details worth knowing before editing this**, both from that same read:

- The value is `host:port`, not a bare IP. LND documents the flag that way and its default carries `:53`. A bare host does pick up `:53` from `verifyPort`, but explicit matches the default's form.
- The key is **not** inert with Tor off. LND's `ParseAddressString` call sits *above* the `if cfg.Tor.Active` block in `config.go`, so `tor.dns` is normalized on every start and must always parse — an unresolvable value would abort startup even with Tor disabled. It just isn't dialed, since `ProxyNet` is only constructed under `tor.active`.

## Test plan

I could not test this on hardware — the dev box went off-network mid-investigation. **This needs a box run before merge.** The diagnosis is fully measured, and the mechanism is confirmed against LND source, but the patched `.s9pk` has only been typechecked.

Reproduce the bug (fresh node required — an established one won't show it):

1. Install LND on a server with **no existing channels or graph**. Leave **Tor Settings** at defaults (Enable Tor on, Skip for clearnet peers on). Select a Bitcoin backend and initialize a wallet.
2. Wait for the chain to sync. LND stays at **Syncing to graph** and never leaves it.
3. `start-cli package logs lnd` shows `Unable to retrieve initial bootstrap peers: no addresses found` every few minutes.

Verify the fix:

4. Install this build on that node. Confirm `lnd.conf` now carries `tor.dns=10.0.3.1:53`.
5. Within a few minutes LND should acquire peers and reach `synced_to_graph: true` — health flips off **Syncing to graph**.
6. Confirm the graph actually populated (`graph_nodes` in `data/graph/mainnet/lnd.sqlite` in the thousands, not 1).

Regression checks on the other two modes — the point is that neither changes behavior:

7. **Tor-only:** turn *off* Skip for clearnet peers. Confirm `tor.dns` is removed from `lnd.conf` and the node still bootstraps (this path resolves through the Tor proxy and was never broken).
8. **Tor off:** disable Tor entirely. Confirm LND starts cleanly with `tor.dns` present — this is the case where the key is parsed but unused, and the one I'd most want eyes on given I couldn't run it.