### PR TITLE
docs: record why the LND chain-backend health check is pinned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ The LND Server check calls the REST `/v1/state` endpoint and returns `success` o
 
 When LND first reaches `synced_to_chain && synced_to_graph` after install, a **Sync Complete** notification is posted to the StartOS notifications panel. The notification fires only once per install — subsequent restarts that re-sync the chain or graph do not re-notify.
 
+LND's own liveness monitor is deliberately off — `healthcheck.chainbackend.attempts` is pinned to `0` in the [enforced section](startos/fileModels/lnd.conf.ts) of `lnd.conf`, against an upstream default of `3`. Exhausting those attempts makes LND request its own shutdown, which duplicates the gating the bitcoind dependency already applies and which the supervisor would only restart. It is also a weaker signal than it sounds: the check issues `uptime` and counts the backend's outbound peers, so it stays green against a backend that answers headers but cannot serve blocks — the failure mode of [bitcoin-core-startos#270](https://github.com/Start9Labs/bitcoin-core-startos/issues/270), which it would not have caught. LND's disk-space and TLS checks report `configured with 0 attempts, skipping it` on every start as well; those two are off by **upstream** default and are not set by this package.
+
 ## Dependencies
 
 | Dependency | Required | Mounted Volume                      | Health Checks Required      | Purpose                                                        |

--- a/startos/fileModels/lnd.conf.ts
+++ b/startos/fileModels/lnd.conf.ts
@@ -39,6 +39,12 @@ const iniBoolean = z
 
 export const shape = z.object({
   // ──── Enforced (StartOS) ────
+  // Upstream defaults this to 3, where exhausting the attempts makes LND
+  // request its own shutdown — which the bitcoind dependency's health gating
+  // already covers, and which the supervisor would only restart. The check
+  // probes `uptime` and the backend's outbound peer count, never block
+  // retrieval, so it stays green through a backend serving headers but not
+  // blocks. LND's disk and TLS checks are off by upstream default, not here.
   'healthcheck.chainbackend.attempts': z.literal(0).catch(0),
   rpclisten: z.tuple([z.literal('0.0.0.0:10009')]).catch(['0.0.0.0:10009']),
   restlisten: z.tuple([z.literal('0.0.0.0:8080')]).catch(['0.0.0.0:8080']),


### PR DESCRIPTION
Follow-up to a report on [bitcoin-core-startos#270](https://github.com/Start9Labs/bitcoin-core-startos/issues/270), which flagged three things about this package. **Two of the three turned out not to be ours, and the third is real but not the defect it looked like.** This PR records the finding; it changes no behavior.

## The claim

> LND ships a health check that watches for exactly this failure — a chain backend that stops answering — and can alert or shut down on it. Configured to zero attempts, it never runs. So on top of the proxy logging below its own filter, the one component that *did* notice was configured not to speak.

## What's actually true

**We do disable it, and it was undocumented.** `healthcheck.chainbackend.attempts` has sat at `z.literal(0)` in the enforced block since a `rough wip` commit with no rationale in the code, the README, or the history. Upstream's default is `3` (`defaultChainAttempts`, `config.go`). That silence is the actual defect here — the pin reads as an oversight, and it just cost a round of re-litigation.

**But it would not have caught #270.** This is the part of the report that doesn't hold. For a bitcoind backend the check is built from `getBitcoindHealthCheckCmd`, which returns `uptime` for any bitcoind ≥ 0.15, plus `checkOutboundPeers` — and that only *warns* on a low peer count, returning `nil`:

```go
if info.Version >= 150000 {
    return "uptime", info.Version, nil
}
```

During #270 the proxy passed `uptime` and `getpeerinfo` straight through; only `getblock` failed. The check would have stayed green the entire time, enabled or not. It probes liveness, not block retrieval.

**And enabling it is not obviously desirable.** Exhausting the attempts makes LND request its own shutdown (`healthcheck.Observation.monitor` → `shutdownFunc`). That duplicates the gating `dependencies.ts` already applies through `healthChecks: ['bitcoind', 'sync-progress']`, and a self-shutdown is something the supervisor would only restart — a loop instead of a signal, whenever bitcoind is down more than ~5 minutes.

So: no behavior change. The pin gets the rationale it should always have had, plus the reason enabling it would not have helped, so the next person reading that line doesn't repeat the investigation.

## Two corrections also recorded

- **The disk and TLS checks are not ours.** `defaultDiskAttempts = 0` and `defaultTLSAttempts = 0` are upstream defaults, so `configured with 0 attempts, skipping it` for those two appears on every stock LND. The report attributed all three lines to this package.
- **This package has never set `routing.assumechanvalid`** — zero references in the repo. It is correctly reported as `DEPRECATED` and `hidden` in 0.21.1's `lncfg/routing.go`, but that is a hand-added user workaround, not something we ship or need to sequence around. #175 was fixed on the bitcoind side, in bitcoin-core-startos#252.

## Not addressed

The third point — `daemon synced-true waiting on sync-progress` reading as perpetually starting — is presentational and already tracked as the open item in #175. Worth noting the health check itself is *not* silent: with `synced_to_chain: false` and `synced_to_graph: true` it reports **"Syncing to chain"**. The trap is that it is indistinguishable from a legitimate sync, and the obvious fix — surfacing `block_height` — would actively mislead, since that keeps advancing off headers while the notifier is stuck. Needs a real signal, not a quick one.

No version bump: comments and README only, so nothing about the built service changes. Rides with the next functional release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)