### PR TITLE
chore: bump LND to 0.21.2-beta; 0.21.1-beta:12 → 0.21.2-beta:0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # would block future lnd bumps, whereas adding lndinit on top keeps the runtime
 # decoupled from lndinit's publish cadence. lndinit drives the bolt → SQLite
 # database migration in startos/versions/current.ts.
-FROM lightninglabs/lnd:v0.21.1-beta
+FROM lightninglabs/lnd:v0.21.2-beta
 
 # v0.21's image switched base from Debian to Alpine and dropped curl, which the
 # startos layer shells into the container for (wallet init/unlock, the migration's
@@ -16,4 +16,4 @@ FROM lightninglabs/lnd:v0.21.1-beta
 # node (assets/import-*.sh).
 RUN apk add --no-cache curl sqlite openssh-client sshpass
 
-COPY --from=lightninglabs/lndinit:v0.1.36-beta-lnd-v0.21.1-beta /bin/lndinit /bin/lndinit
+COPY --from=lightninglabs/lndinit:v0.1.36-beta-lnd-v0.21.2-beta /bin/lndinit /bin/lndinit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1577,9 +1577,9 @@
       "license": "MIT"
     },
     "node_modules/bitcoin-core-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#4f8dff85044df9c6ce1179f7a6090ee648c54ae8",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#eea170b29f5e39c813bd8ec6fd604b1f0dc10cad",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "diskusage": "^1.2.0",
         "tor-startos": "github:Start9Labs/tor-startos#next"
       }
@@ -1769,7 +1769,7 @@
       }
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -13,7 +13,7 @@ export const manifest = setupManifest({
   volumes: ['main'],
   images: {
     lnd: {
-      // Built from ./Dockerfile: lnd v0.21.1-beta + the lndinit binary and the
+      // Built from ./Dockerfile: lnd v0.21.2-beta + the lndinit binary and the
       // sqlite3 CLI, both used by the bolt → SQLite migration
       // (startos/versions/current.ts, startos/sqliteBackend.ts).
       source: {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -5,43 +5,48 @@ import { sdk } from '../sdk'
 import { needsSqliteMigration, runSqliteMigration } from '../sqliteBackend'
 
 export const current = VersionInfo.of({
-  version: '0.21.1-beta:12',
+  version: '0.21.2-beta:0',
   releaseNotes: {
-    en_US: `**Migrate an existing LND node from myNode.**
+    en_US: `Updated LND to 0.21.2-beta, a bug-fix release.
 
-**Initialize Wallet** now offers **Migrate from myNode** alongside Umbrel and StartOS. It verifies the connection to your old node and schedules the migration; starting LND then stops the old node, copies LND's data directory across your local network, converts the database, and brings LND online — so your channels come with you. On a large node this takes hours, with progress shown under Health Checks.
+- Two startup failures during database upgrades are fixed: a node whose payment history held an incomplete blinded route could fail to start, and a database missing its version key could skip a required upgrade.
+- Memory used while syncing the channel graph is now bounded, so a misbehaving peer can no longer make LND buffer an unpredictable amount of data.
+- Fixes a race condition in cooperative channel closes and several onion message decoding errors.
+- Adds \`lncli wallet submitpackage\`, which submits a zero-fee transaction together with a fee-paying child through Bitcoin.
 
-The Umbrel and StartOS migrations are repaired in the same release; neither could previously complete.
+Full notes: https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta`,
+    es_ES: `Se actualizó LND a 0.21.2-beta, una versión de corrección de errores.
 
-After any migration, never start LND on the old device again. Two nodes running from one seed leads to unpredictable behavior or loss of funds.`,
-    es_ES: `**Migre un nodo LND existente desde myNode.**
+- Se corrigen dos fallos de arranque durante las actualizaciones de la base de datos: un nodo cuyo historial de pagos contenía una ruta ciega incompleta podía no arrancar, y una base de datos sin su clave de versión podía omitir una actualización obligatoria.
+- La memoria utilizada al sincronizar el grafo de canales ahora está limitada, de modo que un par que se comporte mal ya no puede hacer que LND almacene una cantidad impredecible de datos.
+- Se corrige una condición de carrera en el cierre cooperativo de canales y varios errores de decodificación de mensajes onion.
+- Se añade \`lncli wallet submitpackage\`, que envía una transacción sin comisión junto con una transacción hija que sí la paga, a través de Bitcoin.
 
-**Inicializar billetera** ahora ofrece **Migrar desde myNode**, junto a Umbrel y StartOS. Verifica la conexión con su nodo antiguo y programa la migración; al iniciar LND, este detiene el nodo antiguo, copia el directorio de datos de LND a través de su red local, convierte la base de datos y pone LND en línea, de modo que sus canales le acompañan. En un nodo grande esto tarda horas, y su progreso aparece en Comprobaciones de estado.
+Notas completas: https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta`,
+    de_DE: `LND wurde auf 0.21.2-beta aktualisiert, eine Fehlerbehebungsversion.
 
-Las migraciones desde Umbrel y StartOS se reparan en esta misma versión; ninguna de las dos podía completarse antes.
+- Zwei Startfehler bei Datenbank-Aktualisierungen sind behoben: Ein Node, dessen Zahlungsverlauf eine unvollständige blinde Route enthielt, konnte nicht starten, und eine Datenbank ohne Versionsschlüssel konnte eine erforderliche Aktualisierung überspringen.
+- Der beim Synchronisieren des Kanalgraphen verwendete Speicher ist jetzt begrenzt, sodass ein sich fehlverhaltender Peer LND nicht mehr dazu bringen kann, eine unvorhersehbare Datenmenge zu puffern.
+- Behebt eine Race Condition beim kooperativen Kanalschluss sowie mehrere Fehler beim Dekodieren von Onion-Nachrichten.
+- Ergänzt \`lncli wallet submitpackage\`, das eine gebührenfreie Transaktion zusammen mit einer gebührenzahlenden Folgetransaktion über Bitcoin einreicht.
 
-Después de cualquier migración, nunca vuelva a iniciar LND en el dispositivo antiguo. Dos nodos que funcionan con la misma semilla provocan un comportamiento impredecible o la pérdida de fondos.`,
-    de_DE: `**Migrieren Sie einen bestehenden LND-Node von myNode.**
+Vollständige Hinweise: https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta`,
+    pl_PL: `Zaktualizowano LND do 0.21.2-beta — wydanie z poprawkami błędów.
 
-**Wallet initialisieren** bietet jetzt **Von myNode migrieren** neben Umbrel und StartOS. Die Aktion prüft die Verbindung zu Ihrem alten Node und plant die Migration; beim Start von LND wird dann der alte Node gestoppt, das Datenverzeichnis von LND über Ihr lokales Netzwerk kopiert, die Datenbank konvertiert und LND online gebracht — Ihre Kanäle ziehen also mit um. Bei einem großen Node dauert das Stunden; den Fortschritt sehen Sie unter Zustandsprüfungen.
+- Naprawiono dwie awarie uruchamiania podczas aktualizacji bazy danych: węzeł, którego historia płatności zawierała niekompletną ślepą trasę, mógł się nie uruchomić, a baza danych bez klucza wersji mogła pominąć wymaganą aktualizację.
+- Pamięć używana podczas synchronizacji grafu kanałów jest teraz ograniczona, więc niepoprawnie działający peer nie może już zmusić LND do buforowania nieprzewidywalnej ilości danych.
+- Naprawiono sytuację wyścigu przy kooperacyjnym zamykaniu kanału oraz kilka błędów dekodowania wiadomości onion.
+- Dodano \`lncli wallet submitpackage\`, które przesyła transakcję bez opłaty wraz z transakcją potomną pokrywającą opłatę, za pośrednictwem Bitcoina.
 
-Die Migrationen von Umbrel und StartOS werden in derselben Version repariert; keine der beiden konnte bisher abgeschlossen werden.
+Pełne informacje: https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta`,
+    fr_FR: `LND a été mis à jour vers 0.21.2-beta, une version corrective.
 
-Starten Sie LND nach einer Migration nie wieder auf dem alten Gerät. Zwei Nodes mit demselben Seed führen zu unvorhersehbarem Verhalten oder zum Verlust von Geldmitteln.`,
-    pl_PL: `**Migruj istniejący węzeł LND z myNode.**
+- Deux échecs de démarrage lors des mises à niveau de la base de données sont corrigés : un nœud dont l'historique de paiements contenait une route aveugle incomplète pouvait ne pas démarrer, et une base de données dépourvue de sa clé de version pouvait ignorer une mise à niveau obligatoire.
+- La mémoire utilisée lors de la synchronisation du graphe des canaux est désormais bornée, de sorte qu'un pair malveillant ne peut plus amener LND à mettre en mémoire tampon une quantité de données imprévisible.
+- Corrige une situation de compétition lors de la fermeture coopérative d'un canal ainsi que plusieurs erreurs de décodage des messages onion.
+- Ajoute \`lncli wallet submitpackage\`, qui soumet une transaction sans frais accompagnée d'une transaction enfant payant les frais, via Bitcoin.
 
-**Zainicjalizuj portfel** oferuje teraz **Migrację z myNode** obok Umbrel i StartOS. Sprawdza połączenie ze starym węzłem i planuje migrację; po uruchomieniu LND zatrzymuje stary węzeł, kopiuje katalog danych LND przez sieć lokalną, konwertuje bazę danych i uruchamia LND — dzięki czemu Twoje kanały przenoszą się razem z Tobą. Na dużym węźle trwa to wiele godzin; postęp śledź w sekcji Kontrole stanu.
-
-W tym samym wydaniu naprawiono migracje z Umbrel i StartOS; żadna z nich nie mogła się wcześniej zakończyć.
-
-Po każdej migracji nigdy nie uruchamiaj ponownie LND na starym urządzeniu. Dwa węzły działające na tym samym ziarnie prowadzą do nieprzewidywalnego zachowania lub utraty środków.`,
-    fr_FR: `**Migrez un nœud LND existant depuis myNode.**
-
-**Initialiser le portefeuille** propose désormais **Migrer depuis myNode**, aux côtés d'Umbrel et de StartOS. L'action vérifie la connexion à votre ancien nœud et planifie la migration ; au démarrage de LND, celui-ci arrête l'ancien nœud, copie le répertoire de données de LND sur votre réseau local, convertit la base de données puis se met en ligne — vos canaux vous suivent donc. Sur un gros nœud, cela prend des heures ; suivez la progression sous Vérifications d'état.
-
-Les migrations depuis Umbrel et StartOS sont réparées dans la même version ; aucune des deux ne pouvait aboutir auparavant.
-
-Après toute migration, ne redémarrez jamais LND sur l'ancien appareil. Deux nœuds partageant une même graine entraînent un comportement imprévisible ou une perte de fonds.`,
+Notes complètes : https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta`,
   },
   migrations: {
     up: async ({ effects, progress }) => {


### PR DESCRIPTION
## Summary

Bumps LND to **v0.21.2-beta** (released 2026-08-13), an upstream bug-fix release. `0.21.1-beta:12` → `0.21.2-beta:0`.

Per `UPDATING.md`, both `Dockerfile` pins move together — the runtime base and the `lndinit` tag that embeds the LND version:

- `FROM lightninglabs/lnd:v0.21.1-beta` → `v0.21.2-beta`
- `COPY --from=lightninglabs/lndinit:v0.1.36-beta-lnd-v0.21.1-beta` → `v0.1.36-beta-lnd-v0.21.2-beta`

Both images are confirmed published on Docker Hub before pinning (`lightninglabs/lnd:v0.21.2-beta`, and `lightninglabs/lndinit:v0.1.36-beta-lnd-v0.21.2-beta` — the lndinit tag lags LND releases and was checked explicitly). The manifest comment naming the pinned LND version is updated to match.

## Upstream highlights

Bug-fix release, no new database migrations, but two fixes to *existing* migration paths that could stop a node from starting:

- [#10982](https://github.com/lightningnetwork/lnd/pull/10982) — payment migration failed on historical routes carrying a blinded total amount with no encrypted recipient data.
- [#10985](https://github.com/lightningnetwork/lnd/pull/10985) — a channeldb initialized without a persisted `metadata/dbp` version key could skip the mandatory v0.21 waiting-proof migration.
- [#10992](https://github.com/lightningnetwork/lnd/pull/10992) — channel-graph sync memory is now bounded per-message and in aggregate; previously a peer could make us buffer an unpredictable number of short channel IDs.
- [#11019](https://github.com/lightningnetwork/lnd/pull/11019) — data race in the legacy cooperative close state machine.
- [#10948](https://github.com/lightningnetwork/lnd/pull/10948) — onion message decoding accepted messages that BOLT 4 requires be rejected.
- [#10900](https://github.com/lightningnetwork/lnd/pull/10900) — new `walletrpc.SubmitPackage` RPC and `lncli wallet submitpackage`, relaying a zero-fee v3/TRUC parent with a fee-paying CPFP child via bitcoind's `submitpackage`.

Full notes: <https://github.com/lightningnetwork/lnd/releases/tag/v0.21.2-beta>

## SDK and dependencies

- `@start9labs/start-sdk` is already pinned at `2.0.9`, the current npm `latest` — no bump.
- `bitcoin-core-startos#next/28.x` and `tor-startos#next` git pins re-resolved to their current tips (dropped from the lock and reinstalled — `npm update` is a no-op on git refs). Lock converged and is byte-stable; a single hoisted start-sdk copy, no nested copy in the lock or on disk.

## Version and release notes

`startos/versions/current.ts` edited in place — a new upstream version resets the revision, so `0.21.2-beta:0`. No new migration rides along, so no historical version file is spun off; the existing bolt → SQLite `up` migration stays on `current`, where the auto-generated `<current` graph vertex still runs it for every older upgrader (and it is state-gated, so an already-converted node no-ops). `0.21.2-beta:0` is confirmed unpublished on the registry (`best` is `0.21.1-beta:12`) and has no origin tag.

Release notes rewritten in all five locales to describe *this* bump only — they don't re-announce the myNode migration work that `:12` already shipped.

## Test plan

- [x] `npm run check` green (`tsc --noEmit`).
- [x] Prettier clean on the edited files.
- [x] Both Docker tags verified pullable via the Docker Hub tag API.
- [ ] `make` / s9pk build — deferred to review per the monitor cycle.

## Not implemented (proposal)

`SubmitPackage` is proxied straight to the chain backend's `submitpackage` RPC, so it needs no package-side configuration and I've left it alone. If we ever want to guarantee it works against the bundled backend, that would be a `versionRange` floor on `bitcoind` for a Core release exposing `submitpackage` — happy to add it if you'd rather assert it explicitly.
